### PR TITLE
分隔線造成的行數計算問題

### DIFF
--- a/PTTLibrary/PTT.py
+++ b/PTTLibrary/PTT.py
@@ -2314,7 +2314,7 @@ class Library(object):
                     OverlapLine = LastPageIndex - PageLineRangeTemp[0] + 1
 
                     # 處理分隔線造成的行數計算錯誤
-                    if PageLineRange[0] > 1 and PageLineRange[0] < 5:
+                    if PageLineRangeTemp[0] > 1 and PageLineRangeTemp[0] < 5:
                         OverlapLine += 1
 
                     if OverlapLine >= 1 and LastPageIndex != 0:

--- a/PTTLibrary/PTT.py
+++ b/PTTLibrary/PTT.py
@@ -1512,6 +1512,10 @@ class Library(object):
                     
                     OverlapLine = LastPageIndex - PageLineRange[0] + 1
 
+                    # 處理分隔線造成的行數計算錯誤
+                    if PageLineRange[0] > 1 and PageLineRange[0] < 5:
+                        OverlapLine += 1
+
                     if OverlapLine >= 1 and LastPageIndex != 0:
                         # print('重疊', OverlapLine, '行')
                         CurrentPageList = CurrentPageList[OverlapLine:]
@@ -2308,6 +2312,11 @@ class Library(object):
                     PageLineRangeTemp = list(map(int, PageLineRangeTemp))[-2:]
                     
                     OverlapLine = LastPageIndex - PageLineRangeTemp[0] + 1
+
+                    # 處理分隔線造成的行數計算錯誤
+                    if PageLineRange[0] > 1 and PageLineRange[0] < 5:
+                        OverlapLine += 1
+
                     if OverlapLine >= 1 and LastPageIndex != 0:
                         print('重疊', OverlapLine, '行')
                         CurrentPageList = CurrentPageList[OverlapLine:]


### PR DESCRIPTION
標題列底下自動產生的分隔線與其下之空白行
在 PTT 的行號中計算為同一行。

因此當 getPost() 與 getMail() 所抓取的文章
其長度僅有一頁多 1 ~ 3 行時，
會出現重複行，位於第一頁最後一行