### PR TITLE
Fix typo, remove trailing spaces

### DIFF
--- a/Demo.py
+++ b/Demo.py
@@ -524,7 +524,7 @@ def Mail():
         print('No Such User')
 
 
-def HashNewMail():
+def HasNewMail():
 
     # 是否有新信範例
 
@@ -564,6 +564,6 @@ if __name__ == '__main__':
     # CallStatus()
     # GiveMoney()
     # Mail()
-    # HashNewMail()
+    # HasNewMail()
 
     PTTBot.logout()

--- a/PTTLibrary/PTT.py
+++ b/PTTLibrary/PTT.py
@@ -1653,7 +1653,7 @@ class Library(Synchronize.SynchronizeAllMethod):
             print('\n'.join(Data))
             print(len(Data))
             raise Exceptions.ParseError(OriScreen)
-        
+
         ID = Data[0]
         Money = Data[1]
         LoginTime = Data[2]

--- a/Test.py
+++ b/Test.py
@@ -640,7 +640,7 @@ def Mail():
     )
 
 
-def HashNewMail():
+def HasNewMail():
 
     result = PTTBot.hasNewMail()
     print(result)
@@ -726,7 +726,7 @@ if __name__ == '__main__':
         # CallStatus()
         # GiveMoney()
         # Mail()
-        # HashNewMail()
+        # HasNewMail()
     except Exception as e:
         traceback.print_tb(e.__traceback__)
         print(e)


### PR DESCRIPTION
I also found there are some packages imported but never used. Not sure it's intended or not, but feel free to let me know if you'd like me to fix them in this PR. For example, `sys` and `ssl` are imported in [`ConnectCore.py`](https://github.com/Truth0906/PTTLibrary/blob/7e4f550bfd0ab37ba0a4ac80f5566e4c58e148c8/PTTLibrary/ConnectCore.py#L2-L6) but were never used.