### PR TITLE
Replace the origin address for WebScoket of PTT

### DIFF
--- a/PTTLibrary/ConnectCore.py
+++ b/PTTLibrary/ConnectCore.py
@@ -188,7 +188,7 @@ class API(object):
                     self._Core = asyncio.get_event_loop().run_until_complete(
                         websockets.connect(
                             'wss://ws.ptt.cc/bbs/',
-                            origin='https://www.ptt.cc'
+                            origin='https://term.ptt.cc'
                         )
                     )
                 else:


### PR DESCRIPTION
Fixes #44 
Change `origin` for connection problem
