### PR TITLE
docs: fix empty Service page and unify changelog date format

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,21 +2,21 @@
 ====================
 | 這裡寫著 PyPtt 的故事。
 
-| 2026.04 修正 ``connect_core`` 編碼回退機制僅支援單向（big5uao → utf-8），導致 ``UseTooManyResources`` 偵測失敗的問題。
-| 2026.04 修正 ``_decode_screen`` 中 ``UseTooManyResources`` 匹配後未設定 ``find_target``，導致編碼回退覆蓋偵測結果的問題。
-| 2026.04 偵測到 ``UseTooManyResources`` 時直接拋出例外，由上層處理重新連線。
+| 2026.04.05 修正 ``connect_core`` 編碼回退機制僅支援單向（big5uao → utf-8），導致 ``UseTooManyResources`` 偵測失敗的問題。
+| 2026.04.05 修正 ``_decode_screen`` 中 ``UseTooManyResources`` 匹配後未設定 ``find_target``，導致編碼回退覆蓋偵測結果的問題。
+| 2026.04.05 偵測到 ``UseTooManyResources`` 時直接拋出例外，由上層處理重新連線。
 
-| 2026.03 重構 ``parse_query_post`` 為 ``PostQueryResult`` dataclass，改善內部結構。
+| 2026.03.26 重構 ``parse_query_post`` 為 ``PostQueryResult`` dataclass，改善內部結構。
 
 | 2025.10.18 PyPtt 支援 Python 3.14 Free Threaded。
 | 2025.10.18 重構測試全面採用 pytest，終於可以一次測完所有功能了！
 | 重構 CI/CD 流程。重構底層與批踢踢連線模組。
 
-| 2024 新增 :doc:`api/get_post_list` API，可以批次取得文章列表。
-| 2024 修正推文解析錯誤。
-| 2024 修正 get_newest_index 錯誤。
-| 2024 支援 Python 3.13。
-| 2024 支援 websockets 13。
+| 2025.09.26 支援 Python 3.13。
+| 2025.09.07 新增 :doc:`api/get_post_list` API，可以批次取得文章列表。
+| 2025.04.21 修正 get_newest_index 錯誤。
+| 2024.12.24 修正推文解析錯誤。
+| 2024.09.09 支援 websockets 13。
 
 | 2022.12.20 PyPtt 1.0.3，logger 改採用以 logging_ 為基底。
 

--- a/docs/service.rst
+++ b/docs/service.rst
@@ -2,6 +2,6 @@ Service
 ===========
 
 
-.. automodule:: PyPtt.service
+.. automodule:: PyPtt.Service
     :members: __init__, set_call_interval
     :undoc-members:


### PR DESCRIPTION
- service.rst: autodoc the Service class (PyPtt.Service) instead of the
  PyPtt.service module, so __init__/set_call_interval docstrings render
  (methods are class members, not module-level members).
- changelog.rst: normalize all entries to YYYY.MM.DD, filling partial
  dates from git history and ordering the formerly year-only block.

https://claude.ai/code/session_018W4ozfUb13g5zmX16bdU7R