### PR TITLE
feat: 版主刪文支援不同提示並新增加註理由

### DIFF
--- a/PyPtt/PTT.py
+++ b/PyPtt/PTT.py
@@ -1090,6 +1090,7 @@ class API:
             NoSuchBoard: 看板不存在。
             NoSuchPost: 文章不存在。
             NoPermission: 沒有權限。
+            ParameterError: 對自己的文章傳入 reason（加註理由僅適用於版主刪除他人文章）。
 
         範例::
 

--- a/PyPtt/PTT.py
+++ b/PyPtt/PTT.py
@@ -1071,7 +1071,7 @@ class API:
 
         return _api_get_bottom_post_list.get_bottom_post_list(self, board)
 
-    def del_post(self, board: str, aid: Optional[str] = None, index: int = 0) -> None:
+    def del_post(self, board: str, aid: Optional[str] = None, index: int = 0, reason: Optional[str] = None) -> None:
         """
         刪除文章。
 
@@ -1079,6 +1079,7 @@ class API:
             board (str): 看板名稱。
             aid (str): 文章編號。
             index (int): 文章編號。
+            reason (str): 板主刪除他人文章時，加註於刪除後標題的理由（僅板主刪除他板友文章時有效）。
 
         Returns:
             None
@@ -1103,7 +1104,7 @@ class API:
                 ptt_bot.logout()
         """
 
-        _api_del_post.del_post(self, board, aid, index)
+        _api_del_post.del_post(self, board, aid, index, reason)
 
     def get_post_list(self, board: str, limit: int = 20, offset: int = 0) -> list[dict]:
         """

--- a/PyPtt/__init__.py
+++ b/PyPtt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.1.2'
+__version__ = '2.1.3'
 __author__ = 'CodingMan'
 __email__ = 'pttcodingman@gmail.com'
 

--- a/PyPtt/_api_del_post.py
+++ b/PyPtt/_api_del_post.py
@@ -66,6 +66,13 @@ def del_post(api, board: str, post_aid: Optional[str] = None, post_index: int = 
         log.logger.info(i18n.delete_post, '...', i18n.success)
         return
 
+    # PTT only offers the "R加註理由" annotation when a moderator deletes
+    # another user's post. On your own post the reason can never be applied,
+    # so reject it rather than silently dropping it.
+    if reason and api.ptt_id.lower() == post_info[data_type.PostField.author].lower():
+        raise exceptions.ParameterError(
+            'reason is only valid when a moderator deletes another user\'s post')
+
     if check_author:
         if api.ptt_id.lower() != post_info[data_type.PostField.author].lower():
             log.logger.info(i18n.delete_post, '...', i18n.fail)

--- a/PyPtt/_api_del_post.py
+++ b/PyPtt/_api_del_post.py
@@ -14,7 +14,7 @@ from . import log
 from . import screens
 
 
-def del_post(api, board: str, post_aid: Optional[str] = None, post_index: int = 0) -> None:
+def del_post(api, board: str, post_aid: Optional[str] = None, post_index: int = 0, reason: Optional[str] = None) -> None:
     _api_util.one_thread(api)
 
     if not api.is_registered_user:
@@ -27,6 +27,8 @@ def del_post(api, board: str, post_aid: Optional[str] = None, post_index: int = 
     if post_aid is not None:
         check_value.check_type(post_aid, str, 'PostAID')
     check_value.check_type(post_index, int, 'PostIndex')
+    if reason is not None:
+        check_value.check_type(reason, str, 'reason')
 
     if len(board) == 0:
         raise exceptions.ParameterError(f'board error parameter: {board}')
@@ -90,20 +92,40 @@ def del_post(api, board: str, post_aid: Optional[str] = None, post_index: int = 
     def confirm_delete_handler(screen):
         api.confirm = True
 
+    # A board moderator deleting another user's post gets an extra
+    # "R加註理由" option that lets us annotate the title shown after deletion.
+    use_reason = bool(reason) and not check_author
+
+    def confirm_delete_response(screen):
+        if use_reason and '加註理由' in screen:
+            return 'r' + command.enter
+        return 'y' + command.enter
+
     target_list = [
         connect_core.TargetUnit('請按任意鍵繼續', response=' '),
-        connect_core.TargetUnit('請確定刪除(Y/N)?[N]', response='y' + command.enter, handler=confirm_delete_handler,
-                                max_match=1),
-        connect_core.TargetUnit(screens.Target.InBoard, break_detect=True),
+        connect_core.TargetUnit('請確定刪除(Y/N', response=confirm_delete_response,
+                                handler=confirm_delete_handler, max_match=1),
     ]
 
-    index = api.connect_core.send(
-        cmd,
-        target_list)
+    if use_reason:
+        target_list.append(
+            connect_core.TargetUnit(
+                '請輸入刪除後要顯示的標題',
+                response=command.ctrl_e + ' ' + reason + command.enter,
+                max_match=1))
+        target_list.append(
+            connect_core.TargetUnit(
+                '請再次確定是否要用上述理由刪除(Y/N',
+                response='y' + command.enter,
+                max_match=1))
 
-    if index == 1:
-        if not api.confirm:
-            log.logger.info(i18n.delete_post, '...', i18n.fail)
-            raise exceptions.NoPermission(i18n.no_permission)
+    target_list.append(
+        connect_core.TargetUnit(screens.Target.InBoard, break_detect=True))
+
+    api.connect_core.send(cmd, target_list)
+
+    if not api.confirm:
+        log.logger.info(i18n.delete_post, '...', i18n.fail)
+        raise exceptions.NoPermission(i18n.no_permission)
 
     log.logger.info(i18n.delete_post, '...', i18n.success)

--- a/tests/test_del_post.py
+++ b/tests/test_del_post.py
@@ -4,6 +4,7 @@ import time
 import pytest
 
 import PyPtt
+from tests import config
 
 
 def test_del_own_post(ptt_bots):
@@ -86,3 +87,37 @@ def test_del_other_post_permission_error(ptt_bots):
         # 5. Try to delete it and expect a permission error
         with pytest.raises(PyPtt.NoPermission):
             ptt_bot.del_post(board=board, index=target_index)
+
+
+def test_del_other_post_with_reason_as_moderator(ptt_bots):
+    """Tests that a board moderator can delete another user's post and
+    annotate a reason on the resulting title."""
+    if not config.MOD_BOARD:
+        pytest.skip('MOD_BOARD env var not set')
+    for ptt_bot in ptt_bots:
+        if ptt_bot.host != PyPtt.HOST.PTT1:
+            continue  # MOD_BOARD is a PTT1 board
+
+        board = config.MOD_BOARD
+        newest_index = ptt_bot.get_newest_index(PyPtt.NewIndex.BOARD, board=board)
+
+        # Find a recent existing post on MOD_BOARD not authored by the bot.
+        target_index = -1
+        for i in range(10):
+            index_to_check = newest_index - i
+            try:
+                post = ptt_bot.get_post(board, index=index_to_check, query=True)
+                if post[PyPtt.PostField.post_status] == PyPtt.PostStatus.EXISTS and not post['author'].startswith(
+                        ptt_bot.ptt_id):
+                    target_index = index_to_check
+                    break
+            except PyPtt.NoSuchPost:
+                continue
+
+        if target_index == -1:
+            pytest.skip(f"Could not find a recent post by another user on {board} for host {ptt_bot.host}")
+
+        ptt_bot.del_post(board=board, index=target_index, reason='PyPtt 自動測試刪文理由')
+
+        deleted_post = ptt_bot.get_post(board, index=target_index, query=True)
+        assert deleted_post[PyPtt.PostField.post_status] == PyPtt.PostStatus.DELETED_BY_MODERATOR

--- a/tests/test_del_post.py
+++ b/tests/test_del_post.py
@@ -89,6 +89,33 @@ def test_del_other_post_permission_error(ptt_bots):
             ptt_bot.del_post(board=board, index=target_index)
 
 
+def test_del_own_post_with_reason_raises(ptt_bots):
+    """Passing a reason for your own post is rejected: the annotation only
+    applies when a moderator deletes another user's post."""
+    for ptt_bot in ptt_bots:
+        post_title = f"PyPtt Reason Reject Test {int(time.time())}"
+        ptt_bot.post(board='Test', title_index=1, title=post_title,
+                     content="This is a test post for deletion.")
+        time.sleep(1)
+
+        newest_index = ptt_bot.get_newest_index(PyPtt.NewIndex.BOARD, board='Test')
+        index = -1
+        for i in range(5):
+            post_data = ptt_bot.get_post('Test', index=newest_index - i)
+            if post_data['author'].startswith(ptt_bot.ptt_id) and \
+                    post_data['title'] == f"[測試] {post_title}":
+                index = newest_index - i
+                break
+        assert index != -1
+
+        # reason on your own post must raise, and must NOT delete it
+        with pytest.raises(PyPtt.exceptions.ParameterError):
+            ptt_bot.del_post(board='Test', index=index, reason='測試理由')
+
+        # clean up: a plain delete still works
+        ptt_bot.del_post(board='Test', index=index)
+
+
 def test_del_other_post_with_reason_as_moderator(ptt_bots):
     """Tests that a board moderator can delete another user's post and
     annotate a reason on the resulting title."""


### PR DESCRIPTION
## 摘要

修正 `del_post` 在**版主刪除他人文章**時靜默失效的問題,並新增**加註刪除理由**功能。

### Bug
PTT 對版主刪除他板友文章顯示的確認提示是 `請確定刪除(Y/N/R加註理由)?[N]`,與一般刪文的 `請確定刪除(Y/N)?[N]` 不同。舊版 `TargetUnit` 只比對後者的完整字串,而它**不是**前者的子字串,因此版主刪文會直接命中 `InBoard` 跳出、**未刪除卻回報成功**。

### 改動
- 確認提示改比對共同前綴 `請確定刪除(Y/N`,同時涵蓋一般與版主提示。
- `del_post` / `_api_del_post.del_post` 新增可選參數 `reason`。版主刪他人文章且帶 `reason` 時:選 `R加註理由` → 標題輸入欄按 `Ctrl-E` 跳到行尾、把理由接在預設 `(已被<版主>刪除) <作者>` 之後 → 回答第二段 `請再次確定是否要用上述理由刪除(Y/N)?[N]`。
- 移除原本永遠不成立的 `index == 1` 權限判斷(只有 `InBoard` 會 break,`send` 不會回傳 1),改用 `api.confirm` 判定(等價或更嚴謹)。
- 新增以 `MOD_BOARD` 為條件的版主加註理由整合測試;bump 版本至 `2.1.3` 以領先 PyPI。

### 實測(CodingMan @ MCP_Test)
| 操作 | status | 列表標題 |
|---|---|---|
| `del_post(reason='...')` | `DELETED_BY_MODERATOR` | `(已被CodingMan刪除) <作者> <理由>` |
| `del_post()` 純版主刪 | `DELETED_BY_MODERATOR` | `(本文已被刪除) <作者>` |

理由過長時由 PTT 端自行截斷標題欄(PTT 本身的長度上限)。

flake8 乾淨;離線單元測試 198 passed / 1 skipped。

🤖 Generated with [Claude Code](https://claude.com/claude-code)