### PR TITLE
fix: get_mail 忽略 search_type/search_condition 搜尋

### DIFF
--- a/PyPtt/__init__.py
+++ b/PyPtt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.1.5'
+__version__ = '2.1.6'
 __author__ = 'CodingMan'
 __email__ = 'pttcodingman@gmail.com'
 

--- a/PyPtt/_api_get_newest_index.py
+++ b/PyPtt/_api_get_newest_index.py
@@ -65,6 +65,7 @@ def get_newest_index(api, index_type: data_type.NewIndex, board: Optional[str] =
         search_list = []
     else:
         check_value.check_type(search_list, list, 'search_list')
+        search_list = list(search_list)  # 別就地改到呼叫端傳進來的 list
 
     if (search_type, search_condition) != (None, None):
         search_list.insert(0, (search_type, search_condition))

--- a/PyPtt/_api_get_post.py
+++ b/PyPtt/_api_get_post.py
@@ -39,6 +39,7 @@ def get_post(api, board: str, aid: Optional[str] = None, index: Optional[int] = 
         search_list = []
     else:
         check_value.check_type(search_list, list, 'search_list')
+        search_list = list(search_list)  # 別就地改到呼叫端傳進來的 list
 
     if (search_type, search_condition) != (None, None):
         search_list.insert(0, (search_type, search_condition))

--- a/PyPtt/_api_mail.py
+++ b/PyPtt/_api_mail.py
@@ -146,6 +146,21 @@ def get_mail(api, index: int, search_type: Optional[data_type.SearchType] = None
     cmd_list.append(command.ctrl_z)
     cmd_list.append('m')
 
+    # search_type/search_condition 併入 search_list（比照 get_post），
+    # 否則單獨使用 search_type 搜尋會被忽略。
+    if search_list is None:
+        search_list = []
+    else:
+        check_value.check_type(search_list, list, 'search_list')
+        search_list = list(search_list)  # 別就地改到呼叫端傳進來的 list
+
+    if (search_type, search_condition) != (None, None):
+        search_list.insert(0, (search_type, search_condition))
+
+    for search_type, search_condition in search_list:
+        check_value.check_type(search_type, data_type.SearchType, 'search_type')
+        check_value.check_type(search_condition, str, 'search_condition')
+
     # 處理條件整理出指令
     _cmd_list = _api_util.get_search_condition_cmd(data_type.NewIndex.MAIL, search_list)
 

--- a/tests/test_get_mail.py
+++ b/tests/test_get_mail.py
@@ -1,6 +1,8 @@
 import PyPtt
 import pytest
 
+from PyPtt import _api_mail, _api_util, data_type
+
 
 def _handle_empty_mailbox(ptt_bot):
     """On LOCALHOST, scripts/bootstrap_local_pttbbs.py always sends each bot a
@@ -12,6 +14,52 @@ def _handle_empty_mailbox(ptt_bot):
         pytest.fail(f"No mail found for host {ptt_bot.host} (account {ptt_bot.ptt_id}). "
                     "bootstrap_local_pttbbs.py seeds a self-mail for every account, "
                     "so this indicates a real regression, not an environment quirk.")
+
+
+def test_get_mail_search_type_is_honored(monkeypatch):
+    """Regression: get_mail must merge search_type/search_condition into the
+    mail search command, the same way get_newest_index does. They were
+    previously ignored, so `get_mail(index, search_type=AUTHOR, ...)` returned
+    the unfiltered mail at that index instead of the author-filtered one.
+
+    Offline unit test: captures the search_list handed to the command builder
+    and stops before any PTT navigation. (log/i18n are initialised by the
+    autouse ptt_bots fixture, which constructs PyPtt.API before this runs.)"""
+
+    class _StopBeforeNetwork(Exception):
+        pass
+
+    captured = {}
+
+    def fake_cmd(index_type, search_list):
+        captured["search_list"] = search_list
+        raise _StopBeforeNetwork
+
+    monkeypatch.setattr(_api_util, "one_thread", lambda api: None)
+    monkeypatch.setattr(_api_util, "get_search_condition_cmd", fake_cmd)
+
+    class _FakeAPI:
+        _is_login = True
+        is_registered_user = True
+
+        def get_newest_index(self, *a, **k):
+            return 999
+
+    # search_type/search_condition alone (no search_list) must reach the builder.
+    # Both the enum and its string name are accepted (SearchType._MagicMeta lets
+    # isinstance('AUTHOR', SearchType) pass), matching get_post's validation loop.
+    for st in ("AUTHOR", data_type.SearchType.AUTHOR):
+        captured.clear()
+        with pytest.raises(_StopBeforeNetwork):
+            _api_mail.get_mail(_FakeAPI(), index=3, search_type=st,
+                               search_condition="someone")
+        assert captured["search_list"] == [(st, "someone")]
+
+    # no search -> no filter (unchanged behaviour)
+    captured.clear()
+    with pytest.raises(_StopBeforeNetwork):
+        _api_mail.get_mail(_FakeAPI(), index=1)
+    assert captured["search_list"] == []
 
 
 def test_get_newest_mail(ptt_bots):


### PR DESCRIPTION
## 問題

`get_mail` 收了 `search_type` / `search_condition` / `search_list` 參數，卻沒把單獨傳入的 `search_type` / `search_condition` 併進 `search_list` 就交給 `get_search_condition_cmd`，導致：

```python
get_mail(index, search_type=SearchType.AUTHOR, search_condition="someone")
```

搜尋條件被整個忽略，回傳的是**未過濾**位置的信件，而非作者過濾後的結果。`get_post` / `get_newest_index` 都有做這個合併，`get_mail` 漏了。

## 修正

- `_api_mail.py`：比照 `get_post` 補上「scalar 併入 search_list」與逐項型別驗證。
- 順手修掉 `get_newest_index` / `get_post` / `get_mail` 三處共通的 latent bug：`search_list.insert(0, ...)` 會就地改到呼叫端傳進來的 list（同一個 list 重複呼叫會越插越多），改成先 `list(...)` 複製。

## 測試

新增離線 regression `test_get_mail_search_type_is_honored`（monkeypatch 掉指令產生器，攔截送進去的 `search_list`，不碰網路）。

離線單元 + parser 套件全綠：`99 passed`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)