### PR TITLE
feat: 支援匿名看板發文（匿名／自訂顯示 ID）(#84)

### DIFF
--- a/PyPtt/PTT.py
+++ b/PyPtt/PTT.py
@@ -436,7 +436,8 @@ class API:
         return _api_get_newest_index.get_newest_index(
             self, index_type, board, search_type, search_condition, search_list)
 
-    def post(self, board: str, title_index: int, title: str, content: str, sign_file: [str | int] = 0) -> None:
+    def post(self, board: str, title_index: int, title: str, content: str, sign_file: [str | int] = 0,
+             anonymous: bool = False, display_id: Optional[str] = None) -> None:
         """
         發文。
 
@@ -446,6 +447,12 @@ class API:
             title (str): 文章標題。
             content (str): 文章內容。
             sign_file  (str | int): 編號或隨機簽名檔 (x)，預設為 0 (不選)。
+            anonymous (bool): 是否匿名發文，預設為 False。僅在該看板本身具有匿名 (BRD_ANONYMOUS)
+                屬性時才會生效，一般看板無法透過此參數強制匿名；PyPtt 只能在該提示出現時回覆它。
+            display_id (str): 匿名發文時欲顯示的自訂名稱；預設為 None，代表使用 pttbbs 預設值
+                (預設匿名板為 "Anonymous."，否則為原 ID)。pttbbs 會在暱名 (含預設的 "Anonymous")
+                後方加上一個 "."（例如 display_id='Fox' 會顯示為 "Fox."），此為 pttbbs 固定行為，
+                無法調整。僅能在 anonymous=True 時使用。
 
         Returns:
             None
@@ -455,6 +462,7 @@ class API:
             RequireLogin: 需要登入。
             NoSuchBoard: 看板不存在。
             NoPermission: 沒有發佈權限。
+            ParameterError: display_id 於 anonymous=False 時提供。
 
         範例::
 
@@ -464,13 +472,19 @@ class API:
             try:
                 # .. login ..
                 ptt_bot.post(board='Test', title_index=1, title='PyPtt 程式貼文測試', content='測試內容', sign_file=0)
+                # 匿名發文 (需看板本身具有匿名屬性)
+                ptt_bot.post(board='AnonBoard', title_index=1, title='匿名貼文測試', content='測試內容',
+                             sign_file=0, anonymous=True)
+                # 匿名發文並自訂顯示名稱
+                ptt_bot.post(board='AnonBoard', title_index=1, title='匿名貼文測試', content='測試內容',
+                             sign_file=0, anonymous=True, display_id='Fox')
                 # .. do something ..
             finally:
                 ptt_bot.logout()
 
         """
 
-        _api_post.post(self, board, title, content, title_index, sign_file)
+        _api_post.post(self, board, title, content, title_index, sign_file, anonymous, display_id)
 
     def comment(self, board: str, comment_type: data_type.CommentType, content: str, aid: Optional[str] = None,
                 index: int = 0) -> None:

--- a/PyPtt/__init__.py
+++ b/PyPtt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.1.7'
+__version__ = '2.2.0'
 __author__ = 'CodingMan'
 __email__ = 'pttcodingman@gmail.com'
 

--- a/PyPtt/_api_post.py
+++ b/PyPtt/_api_post.py
@@ -92,7 +92,49 @@ sign_file_list = [str(x) for x in range(0, 10)]
 sign_file_list.append('x')
 
 
-def post(api, board: str, title: str, content: str, title_index: int, sign_file: [str | int]) -> None:
+# --- post()'s `anonymous` / `display_id` params (issue #84) ---
+#
+# pttbbs only shows the "請輸入你想用的ID" / "確定[y/N]?" prompt pair when the
+# *board itself* carries BRD_ANONYMOUS server-side (mbbsd/edit.c write_header,
+# `if (currbrdattr & BRD_ANONYMOUS)`). On a normal board the two TargetUnits
+# below simply never match anything on screen -- there is no way for PyPtt to
+# force anonymity on a board that isn't flagged anonymous. See
+# scripts/mkboard.py / scripts/bootstrap_local_pttbbs.py's AnonTest board for
+# how to provision one locally.
+#
+# Response mapping, matching pttbbs' own rules for that prompt:
+#   anonymous=False              -> 'r' (real userid; safe default, and a
+#                                    no-op on non-anonymous boards)
+#   anonymous=True,  no display_id -> '' (Enter; "Anonymous." -- pttbbs
+#                                    appends the same trailing '.' as the
+#                                    display_id case below -- on a
+#                                    default-anonymous board, real userid
+#                                    otherwise -- pttbbs' own behavior)
+#   anonymous=True,  display_id  -> that string; pttbbs appends a trailing
+#                                    '.' to it (e.g. display_id='Fox' shows
+#                                    up as author 'Fox.') -- fixed pttbbs
+#                                    behavior, not adjustable by PyPtt.
+def _anonymous_response(anonymous: bool, display_id: [str | None]) -> str:
+    if display_id is not None:
+        check_value.check_type(display_id, str, 'display_id')
+        if not anonymous:
+            raise exceptions.ParameterError('display_id requires anonymous=True')
+        # pttbbs (mbbsd/edit.c) treats a leading '-' as "this is a deleted
+        # name" and re-shows the same prompt instead of accepting it, which
+        # would make PyPtt's TargetUnit answer it the same way forever.
+        if display_id.startswith('-'):
+            raise exceptions.ParameterError("display_id must not start with '-'")
+        for c in display_id:
+            if ord(c) < 0x20 or ord(c) == 0x7f:
+                raise exceptions.ParameterError(
+                    f'display_id must not contain control characters (found {c!r})')
+        return display_id
+
+    return '' if anonymous else 'r'
+
+
+def post(api, board: str, title: str, content: str, title_index: int, sign_file: [str | int],
+         anonymous: bool = False, display_id: [str | None] = None) -> None:
     _api_util.one_thread(api)
 
     if not api._is_login:
@@ -105,9 +147,12 @@ def post(api, board: str, title: str, content: str, title_index: int, sign_file:
     check_value.check_type(title_index, int, 'title_index')
     check_value.check_type(title, str, 'title')
     check_value.check_type(content, str, 'content')
+    check_value.check_type(anonymous, bool, 'anonymous')
 
     if str(sign_file).lower() not in sign_file_list:
         raise exceptions.ParameterError(f'wrong parameter sign_file: {sign_file}')
+
+    anonymous_response = _anonymous_response(anonymous, display_id)
 
     _api_util.check_board(api, board)
     _api_util.goto_board(api, board)
@@ -147,7 +192,17 @@ def post(api, board: str, title: str, content: str, title_index: int, sign_file:
 
     target_list = [
         connect_core.TargetUnit('任意鍵繼續', break_detect=True),
-        connect_core.TargetUnit('確定要儲存檔案嗎', response='s' + command.enter),
+        # max_match=1: pttbbs' "檔案處理" screen keeps every answered prompt's
+        # echoed text on screen as the flow proceeds through the next ones
+        # (confirmed live -- "確定要儲存檔案嗎？ s" stays visible through the
+        # anonymous-post prompts below). Without max_match=1 this target
+        # re-matches on every later screen in the same flow and re-sends
+        # 's' + Enter into whatever field currently has focus (e.g. the
+        # anonymous-ID or confirm prompt), corrupting the answer.
+        connect_core.TargetUnit('確定要儲存檔案嗎', response='s' + command.enter, max_match=1),
+        # Only shown on a BRD_ANONYMOUS board -- no-op on a normal board.
+        connect_core.TargetUnit('請輸入你想用的ID', response=anonymous_response + command.enter, max_match=1),
+        connect_core.TargetUnit('確定[y/N]', response='y' + command.enter, max_match=1),
         connect_core.TargetUnit('x=隨機', response=str(sign_file) + command.enter),
     ]
     api.connect_core.send(

--- a/scripts/bootstrap_local_pttbbs.py
+++ b/scripts/bootstrap_local_pttbbs.py
@@ -17,8 +17,10 @@ Usage:
 Steps:
     (a) generate `.PASSWDS` for pypttbot1 / pypttbot2 / CodingMan and load it
         into the container via `uhash_loader`.
-    (b) create boards Test / Python / Announce (no moderator) and PyPttMod
-        (moderated by pypttbot1), then reload the board + BM shm caches.
+    (b) create boards Test / Python / Announce (no moderator), PyPttMod
+        (moderated by pypttbot1), and AnonTest (BRD_ANONYMOUS +
+        BRD_DEFAULTANONYMOUS, for tests/test_post_anonymous.py), then
+        reload the board + BM shm caches.
     (c) log in via this repo's PyPtt (host=LOCALHOST) and seed the data the
         test suite reads: a post on Test and on Python by each bot, a
         self-mail for each bot (so `get_newest_index(NewIndex.MAIL) > 0`),
@@ -55,12 +57,17 @@ ACCOUNTS = [
 # misaligning the post-composer keystrokes on boards with no post-type list.
 POST_TYPES = '測試,問題,心得,閒聊,公告,其他'
 
-# (board, moderator_id, post_types)
+# (board, moderator_id, post_types[, anon_mode]) -- anon_mode defaults to ''
+# (not anonymous) when omitted; see scripts/mkboard.py's docstring.
 BOARDS = [
     ('Test', '', POST_TYPES),
     ('Python', '', POST_TYPES),
     ('Announce', '', POST_TYPES),
     ('PyPttMod', 'pypttbot1', POST_TYPES),
+    # BRD_ANONYMOUS + BRD_DEFAULTANONYMOUS: an Enter response to the "請輸入
+    # 你想用的ID" prompt deterministically resolves to "Anonymous." here, which
+    # is what tests/test_post_anonymous.py (issue #84) relies on.
+    ('AnonTest', '', POST_TYPES, 'defanon'),
 ]
 
 
@@ -100,8 +107,10 @@ def step_boards(container):
     print('--- (b) boards ---')
     mkboard_script = os.path.join(REPO_ROOT, 'scripts', 'mkboard.py')
     run(CONTAINER_TOOL, 'cp', mkboard_script, f'{container}:/home/bbs/mkboard.py')
-    for board, moderator, post_types in BOARDS:
-        container_exec(container, '/usr/bin/python3', 'mkboard.py', board, moderator, post_types,
+    for board_spec in BOARDS:
+        board, moderator, post_types, *anon_mode = board_spec
+        args = [board, moderator, post_types, *anon_mode]
+        container_exec(container, '/usr/bin/python3', 'mkboard.py', *args,
                         user='bbs', cwd='/home/bbs')
     container_exec(container, './bin/shmctl', 'reloadbcache', user='bbs', cwd='/home/bbs')
     container_exec(container, './bin/shmctl', 'bBMC', user='bbs', cwd='/home/bbs')

--- a/scripts/mkboard.py
+++ b/scripts/mkboard.py
@@ -9,13 +9,18 @@ own it as `bbs:bbs`, and `shmctl reloadbcache` requires `-u bbs` shmat access
 — see `bootstrap_local_pttbbs.py`).
 
 Usage (inside the container):
-    python3 mkboard.py <board_name> [bm_id] [posttype1,posttype2,...]
+    python3 mkboard.py <board_name> [bm_id] [posttype1,posttype2,...] [anon_mode]
 
     board_name   Board id, e.g. "Test".
     bm_id        Moderator's ptt_id. Omit or pass "" for no moderator.
     posttype     Comma-separated "文章種類" category names (up to 8, each at
                  most 2 Big5 characters), e.g. "問題,心得,其他". Omit or pass
                  "" to leave the board without a post-type list.
+    anon_mode    "anon" sets BRD_ANONYMOUS (0x40, board carries the 匿名發文
+                 prompt but defaults to the real id), "defanon" additionally
+                 sets BRD_DEFAULTANONYMOUS (0x80, prompt defaults to
+                 "Anonymous"). Omit or pass "" to leave the board non-
+                 anonymous (attr unchanged).
 
 After running this (and for every board it touches), reload the live board
 cache and BM cache as the `bbs` user:
@@ -37,6 +42,19 @@ OFF_TITLE, L_TITLE = OFF_BRD + L_BRD, BTLEN + 1
 OFF_BM, L_BM = OFF_TITLE + L_TITLE, IDLEN * 3 + 3
 OFF_POSTTYPE, L_POSTTYPE = 172, 33
 OFF_POSTTYPE_F = 205
+
+# brdattr is a packed little-endian uint32 at byte offset 104 (see
+# pttbbs/include/pttstruct.h boardheader_t). BRD_ANONYMOUS (0x40) and
+# BRD_DEFAULTANONYMOUS (0x80) both fit in its low byte, so OR-ing that one
+# byte is enough -- no need to touch the other 3 bytes of the word.
+OFF_BRDATTR = 104
+BRD_ANONYMOUS = 0x40
+BRD_DEFAULTANONYMOUS = 0x80
+ANON_MODES = {
+    '': 0,
+    'anon': BRD_ANONYMOUS,
+    'defanon': BRD_ANONYMOUS | BRD_DEFAULTANONYMOUS,
+}
 
 
 def setfield(hdr: bytearray, off: int, length: int, raw: bytes) -> None:
@@ -68,6 +86,9 @@ def main():
     bm_id = args[1] if len(args) > 1 else ''
     posttype_csv = args[2] if len(args) > 2 else ''
     posttypes = [t for t in posttype_csv.split(',') if t] if posttype_csv else []
+    anon_mode = args[3] if len(args) > 3 else ''
+    if anon_mode not in ANON_MODES:
+        sys.exit(f'unknown anon_mode: {anon_mode!r} (expected "", "anon", or "defanon")')
 
     title_b = ('測試 ◎PyPtt ' + board_name).encode('big5')
 
@@ -93,6 +114,7 @@ def main():
     setfield(hdr, OFF_BM, L_BM, bm_id.encode('latin1'))
     setfield(hdr, OFF_POSTTYPE, L_POSTTYPE, encode_posttypes(posttypes))
     hdr[OFF_POSTTYPE_F] = 0
+    hdr[OFF_BRDATTR] |= ANON_MODES[anon_mode]
 
     if existing:
         idx = existing[0]
@@ -113,6 +135,7 @@ def main():
     print('board dir:', bdir, 'exists' if os.path.isdir(bdir) else 'MISSING')
     print('BM field set to:', bm_id or '(none)')
     print('posttype set to:', posttypes or '(none)')
+    print('anon_mode set to:', anon_mode or '(none)')
     print('.BRD now', len(data) // SIZE, 'boards,', len(data), 'bytes')
 
 

--- a/tests/test_post_anonymous.py
+++ b/tests/test_post_anonymous.py
@@ -1,0 +1,96 @@
+"""Tests PyPtt issue #84 (匿名發文): post()'s anonymous/display_id params
+against a board that actually carries pttbbs' BRD_ANONYMOUS/BRD_DEFAULTANONYMOUS
+flags. Only pttbbs boards flagged this way ever show the anonymous prompt --
+PyPtt cannot force anonymity on a normal board (see PyPtt/_api_post.py). Only
+scripts/bootstrap_local_pttbbs.py's local container provisions such a board
+(AnonTest), so this file is LOCALHOST-only.
+"""
+import os
+import time
+import uuid
+
+import pytest
+
+import PyPtt
+from PyPtt import PostField, NewIndex
+
+if os.environ.get('PTT_HOST') != 'LOCALHOST':
+    pytest.skip(
+        'test_post_anonymous.py needs the AnonTest board, which only '
+        'scripts/bootstrap_local_pttbbs.py provisions. Set PTT_HOST=LOCALHOST to run.',
+        allow_module_level=True)
+
+ANON_BOARD = 'AnonTest'
+
+
+def _find_own_post(ptt_bot, title_marker):
+    """Scan back from the newest post on ANON_BOARD for the one whose title
+    contains title_marker, and return its parsed post dict."""
+    newest_index = ptt_bot.get_newest_index(index_type=NewIndex.BOARD, board=ANON_BOARD)
+    for i in range(10):
+        index = newest_index - i
+        if index <= 0:
+            break
+        post = ptt_bot.get_post(board=ANON_BOARD, index=index)
+        if title_marker in post[PostField.title]:
+            return post
+    raise AssertionError(f'could not find a post titled with marker {title_marker!r}')
+
+
+def test_post_anonymous(ptt_bots):
+    """anonymous=True, display_id=None -> pttbbs masks the author as
+    'Anonymous.' (AnonTest is bootstrapped BRD_DEFAULTANONYMOUS, so an empty
+    response to the anon prompt means 'Anonymous', not the real id; pttbbs
+    appends a trailing '.' the same way it does for a custom display_id)."""
+    ptt_bot = ptt_bots[0]
+    marker = uuid.uuid4().hex[:12]
+    title = f'PyPtt anon test {marker}'
+
+    ptt_bot.post(board=ANON_BOARD, title_index=1, title=title,
+                 content='PyPtt anonymous post test content.\n', sign_file=0,
+                 anonymous=True)
+
+    time.sleep(1)
+    post = _find_own_post(ptt_bot, marker)
+
+    author = post[PostField.author]
+    assert author.split(' ')[0] == 'Anonymous.', f'expected masked author "Anonymous.", got {author!r}'
+    assert ptt_bot.ptt_id not in author, f'real ptt_id leaked into author field: {author!r}'
+
+
+def test_post_anonymous_with_display_id(ptt_bots):
+    """anonymous=True, display_id='PyPttFox' -> pttbbs masks the author as
+    the custom name plus a trailing '.' (pttbbs behavior, not adjustable)."""
+    ptt_bot = ptt_bots[0]
+    marker = uuid.uuid4().hex[:12]
+    title = f'PyPtt anon custom id test {marker}'
+    display_id = 'PyPttFox'
+
+    ptt_bot.post(board=ANON_BOARD, title_index=1, title=title,
+                 content='PyPtt anonymous post (custom display id) test content.\n', sign_file=0,
+                 anonymous=True, display_id=display_id)
+
+    time.sleep(1)
+    post = _find_own_post(ptt_bot, marker)
+
+    author = post[PostField.author]
+    assert author.split(' ')[0] == f'{display_id}.', f'expected masked author "{display_id}.", got {author!r}'
+    assert ptt_bot.ptt_id not in author, f'real ptt_id leaked into author field: {author!r}'
+
+
+def test_post_not_anonymous_shows_real_id(ptt_bots):
+    """anonymous=False (default) -> even on an anonymous-capable board, the
+    real ptt_id is used (safe default, backward compatible with pre-#84
+    callers of post())."""
+    ptt_bot = ptt_bots[0]
+    marker = uuid.uuid4().hex[:12]
+    title = f'PyPtt non-anon test {marker}'
+
+    ptt_bot.post(board=ANON_BOARD, title_index=1, title=title,
+                 content='PyPtt non-anonymous post test content.\n', sign_file=0)
+
+    time.sleep(1)
+    post = _find_own_post(ptt_bot, marker)
+
+    author = post[PostField.author]
+    assert author.split(' ')[0] == ptt_bot.ptt_id, f'expected real author {ptt_bot.ptt_id!r}, got {author!r}'


### PR DESCRIPTION
## Summary
Closes #84

新增匿名看板發文支援。`post()` 新增 `anonymous` / `display_id` 參數，於 `BRD_ANONYMOUS` 看板回應 mbbsd 的兩道提問（`請輸入你想用的ID`、`確定[y/N]`）：

| 參數 | 行為 |
|---|---|
| `anonymous=False`（預設） | 送 `r`，使用原 ID |
| `anonymous=True, display_id=None` | 匿名，作者顯示 `Anonymous.` |
| `anonymous=True, display_id='X'` | 自訂顯示 ID，作者顯示 `X.`（pttbbs 固定補尾綴 `.`） |

只有目標看板 server 端帶 `BRD_ANONYMOUS` 時提問才會出現；一般看板此參數為 no-op（貼合 pttbbs 實際行為，無法對非匿名板強制匿名）。

### 順帶修正一個潛在 bug
既有的 `確定要儲存檔案嗎` `TargetUnit` 未設 `max_match`，在 pttbbs 堆疊式「檔案處理」畫面上會重複比對、把 `s\r` 灌進後續欄位，一旦有新提問就進入無窮迴圈。已與兩個新 `TargetUnit` 一併加上 `max_match=1`。

## Testing
- 於本地 pttbbs image（`bbsdocker/imageptt`）驗證，新增 `tests/test_post_anonymous.py`（LOCALHOST-gated，3 tests）：以 `get_post` 讀回作者，確認 `Anonymous.` / `自訂.` / 原 ID 三種呈現。
- `scripts/mkboard.py` 可設 `BRD_ANONYMOUS`(0x40)/`BRD_DEFAULTANONYMOUS`(0x80)；`scripts/bootstrap_local_pttbbs.py` 新增 `AnonTest` 看板供測試。
- 一般發文／回文回歸測試通過（改到共用 TargetUnit）；no-network unit suite `208 passed`；flake8 無新增問題。
- 版本 `2.1.7` → `2.2.0`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115w5VpjDM1XoVzTGaNz5qa
