### PR TITLE
docs: 補上樂透 get_lottery / bet_lottery 文件

### DIFF
--- a/PyPtt/__init__.py
+++ b/PyPtt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.2.1'
+__version__ = '2.2.2'
 __author__ = 'CodingMan'
 __email__ = 'pttcodingman@gmail.com'
 

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -63,3 +63,9 @@ APIs
    set_board_title
    mark_post
    bucket
+
+樂透相關
+----------------
+.. toctree::
+
+   lottery

--- a/docs/api/lottery.rst
+++ b/docs/api/lottery.rst
@@ -1,0 +1,14 @@
+lottery
+==========
+
+.. _api-get-lottery:
+
+.. automodule:: PyPtt.API
+   :members: get_lottery
+   :noindex:
+
+.. _api-bet-lottery:
+
+.. automodule:: PyPtt.API
+   :members: bet_lottery
+   :noindex:

--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -151,4 +151,9 @@
     板主刪除他人文章並指定 :ref:`bad-post-type` 時，文章已成功刪除，但 PTT 端沒有完成惡退（劣文）
     記錄流程（例如文章太舊而跳過惡退選單）。呼叫端應理解「刪除成功，但惡退未記錄」。
 
+.. py:exception:: PyPtt.exceptions.NoSuchLottery
+    :module: PyPtt
+
+    查無樂透，該看板目前並沒有舉辦樂透，或樂透已封盤/開獎。
+
 .. _水桶: https://pttpedia.fandom.com/zh/wiki/%E6%B0%B4%E6%A1%B6

--- a/docs/type.rst
+++ b/docs/type.rst
@@ -564,3 +564,69 @@ PostField
 .. py:attribute:: PyPtt.PostField.is_unconfirmed
 
     文章是否為未確認文章
+
+.. _lottery-field:
+
+LotteryField
+--------------
+* 樂透資料欄位。
+
+.. py:attribute:: PyPtt.LotteryField.board
+
+    看板名稱
+
+.. py:attribute:: PyPtt.LotteryField.price
+
+    每張價格
+
+.. py:attribute:: PyPtt.LotteryField.total
+
+    已下注總額
+
+.. py:attribute:: PyPtt.LotteryField.options
+
+    下注選項清單，詳見 :ref:`lottery-option-field`
+
+.. _lottery-option-field:
+
+LotteryOptionField
+--------------------
+* 樂透下注選項資料欄位。
+
+.. py:attribute:: PyPtt.LotteryOptionField.index
+
+    選項編號
+
+.. py:attribute:: PyPtt.LotteryOptionField.name
+
+    選項名稱
+
+.. py:attribute:: PyPtt.LotteryOptionField.sold
+
+    已售出張數
+
+.. _lottery-bet-field:
+
+LotteryBetField
+------------------
+* 樂透下注結果資料欄位。
+
+.. py:attribute:: PyPtt.LotteryBetField.board
+
+    看板名稱
+
+.. py:attribute:: PyPtt.LotteryBetField.item
+
+    下注選項編號
+
+.. py:attribute:: PyPtt.LotteryBetField.name
+
+    選項名稱
+
+.. py:attribute:: PyPtt.LotteryBetField.amount
+
+    購買張數
+
+.. py:attribute:: PyPtt.LotteryBetField.cost
+
+    本次下注花費的 Ptt 幣總額


### PR DESCRIPTION
## Summary
- `docs/api/lottery.rst`（新增）：`get_lottery` / `bet_lottery` 同頁雙 method，格式比照 `give_money.rst` / `login_logout.rst`。
- `docs/api/index.rst`：新增「樂透相關」章節與 toctree，指向 `lottery`。
- `docs/exceptions.rst`：補上 `PyPtt.exceptions.NoSuchLottery` 例外說明。
- `docs/type.rst`：補上 `LotteryField` / `LotteryOptionField` / `LotteryBetField` 三個欄位列舉（含各成員說明）。
- `PyPtt/__init__.py`：版本 2.2.1 → 2.2.2（PyPI 已有 2.2.1，避免 CI 版本檢查失敗）。

補上 #207（v2.2.1 上線）當時遺漏的樂透 API 文件。Closes #95 已由 #207 完成，此 PR 純補文件。

## Test plan
- [x] `sphinx -b html . _build/html_lottery_check` 本地建置成功，0 warning。
- [x] `api/lottery.html` 內含 `get_lottery` 與 `bet_lottery` 兩個 method。
- [x] `exceptions.html` 內含 `NoSuchLottery`。
- [x] `type.html` 內含 `LotteryField` / `LotteryOptionField` / `LotteryBetField`。
- [x] `git status` 確認僅 5 個原始檔變更，`docs/_build/` 未被追蹤（已在 .gitignore）。

https://claude.ai/code/session_0115w5VpjDM1XoVzTGaNz5qa