### PR TITLE
fix: bet_lottery sent keys into screens it was not waiting for

### DIFF
--- a/PyPtt/__init__.py
+++ b/PyPtt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.2.7'
+__version__ = '2.2.8'
 __author__ = 'CodingMan'
 __email__ = 'pttcodingman@gmail.com'
 

--- a/PyPtt/_api_lottery.py
+++ b/PyPtt/_api_lottery.py
@@ -78,7 +78,14 @@ def _leave_ticket_screen(api) -> None:
     target_list = [
         connect_core.TargetUnit(screens.Target.InBoard, break_detect=True),
     ]
-    api.connect_core.send('q', target_list)
+    # When we are bailing out on top of a vmsg() bar (現金不夠 / 板主已經停止下注了),
+    # that bar eats the 'q' as its "press any key" and drops us back on the
+    # 種類 prompt still inside ticket(). Nothing new is painted in that case
+    # (pttbbs only sends what changed, and the ticket screen did not), so there
+    # is no screen to detect it by -- and ticket()'s vkey_purge() throws away
+    # anything pipelined behind the 'q'. Hence: send it again.
+    if api.connect_core.send('q', target_list) == -1:
+        api.connect_core.send('q', target_list)
 
 
 def get_lottery(api, board: str) -> Dict:
@@ -119,39 +126,59 @@ def bet_lottery(api, board: str, item: int = 1, amount: int = 1) -> Dict:
     log.logger.info(i18n.replace(i18n.bet_lottery, board))
 
     ori_screen = _enter_ticket_screen(api, board)
-    before = _parse_lottery_screen(board, ori_screen)
 
-    options = before[LotteryField.options]
-    if item > len(options):
+    # Everything below drives mbbsd/gamble.c's ticket() loop, which only ever
+    # ends on 'q'. Bailing out without leaving it strands the whole session
+    # inside the lottery menu, so the exit is unconditional.
+    try:
+        before = _parse_lottery_screen(board, ori_screen)
+
+        options = before[LotteryField.options]
+        if item > len(options):
+            raise exceptions.ParameterError(
+                f'item {item} error, board {board} only has {len(options)} lottery options')
+
+        name = options[item - 1][LotteryOptionField.name]
+        price = before[LotteryField.price]
+
+        # Order matters. pttbbs never clears the 要買多少份呢 prompt, so it is
+        # still on screen once the purchase goes through -- matching it again
+        # would replay the Ctrl-Y/amount keys into the confirmation screen and
+        # then blindly wait out a whole screen_timeout. The error branches go
+        # first for the same reason: vmsg() paints 按任意鍵繼續 on the right of
+        # its own message bar (mbbsd/vtuikit.c: vshowmsg()'s VMSG_MSG_FLOAT),
+        # so 現金不夠/板主已經停止下注了 share a screen with it.
+        target_list = [
+            connect_core.TargetUnit('現金不夠', break_detect=True, exceptions_=exceptions.NoMoney()),
+            connect_core.TargetUnit(
+                '板主已經停止下注了', break_detect=True, exceptions_=exceptions.NoSuchLottery(board)),
+            connect_core.TargetUnit('按任意鍵繼續', break_detect=True),
+            # buy_ticket_ui()'s getdata_str() pre-fills this field with "1" and
+            # parks the cursor after it (mbbsd/vtuikit.c: vgetstring() copies
+            # defstr into buf then sets icurr = iend = strlen(buf)); typing
+            # digits without clearing first inserts after the "1" (e.g. "3"
+            # becomes "13"), so Ctrl-Y (clear-to-start) must come first.
+            connect_core.TargetUnit(
+                '要買多少份呢', response=command.ctrl_y + str(amount) + command.enter),
+        ]
+        api.connect_core.send(str(item), target_list)
+
+        # Dismiss the purchase-confirmation picture, back to the (refreshed)
+        # ticket screen. pttbbs redraws differentially and each send() starts
+        # from a blank screen parser, so only what actually *changed* shows up
+        # here -- 請選擇要購買的種類 is unchanged and therefore never
+        # retransmitted. show_ticket_data()'s repaint of the bet table is, so
+        # target that instead (請選擇要購買的種類 stays as a fallback for the
+        # full-redraw case).
+        target_list = [
+            connect_core.TargetUnit(
+                '板主已經停止下注了', break_detect=True, exceptions_=exceptions.NoSuchLottery(board)),
+            connect_core.TargetUnit('目前下注狀況', break_detect=True),
+            connect_core.TargetUnit('請選擇要購買的種類', break_detect=True),
+        ]
+        api.connect_core.send(command.space, target_list)
+    finally:
         _leave_ticket_screen(api)
-        raise exceptions.ParameterError(
-            f'item {item} error, board {board} only has {len(options)} lottery options')
-
-    name = options[item - 1][LotteryOptionField.name]
-    price = before[LotteryField.price]
-
-    target_list = [
-        # buy_ticket_ui()'s getdata_str() pre-fills this field with "1" and
-        # parks the cursor after it (mbbsd/vtuikit.c: vgetstring() copies
-        # defstr into buf then sets icurr = iend = strlen(buf)); typing
-        # digits without clearing first inserts after the "1" (e.g. "3"
-        # becomes "13"), so Ctrl-Y (clear-to-start) must come first.
-        connect_core.TargetUnit(
-            '要買多少份呢', response=command.ctrl_y + str(amount) + command.enter),
-        connect_core.TargetUnit('現金不夠', break_detect=True, exceptions_=exceptions.NoMoney()),
-        connect_core.TargetUnit(
-            '板主已經停止下注了', break_detect=True, exceptions_=exceptions.NoSuchLottery(board)),
-        connect_core.TargetUnit('按任意鍵繼續', break_detect=True),
-    ]
-    api.connect_core.send(str(item), target_list)
-
-    # dismiss the purchase-confirmation picture, back to the (refreshed) ticket screen
-    target_list = [
-        connect_core.TargetUnit('請選擇要購買的種類', break_detect=True),
-    ]
-    api.connect_core.send(command.space, target_list)
-
-    _leave_ticket_screen(api)
 
     log.logger.info(i18n.replace(i18n.bet_lottery, board), '...', i18n.success)
 

--- a/tests/test_lottery.py
+++ b/tests/test_lottery.py
@@ -10,6 +10,7 @@ real PTT hosts. item/amount range validation raises before any board
 navigation, so those run everywhere.
 """
 import contextlib
+import re
 
 import pytest
 
@@ -20,6 +21,20 @@ from PyPtt import _api_lottery
 LOTTERY_BOARD = 'PyPttLottery'
 LOTTERY_PRICE = 10
 LOTTERY_ITEMS = ('Alpha', 'Bravo', 'Charlie')
+# PyPtt.API.bet_lottery's check_range() ceiling, i.e. the most that can be spent
+# in a single bet.
+MAX_AMOUNT = 9999
+
+_money_pattern = re.compile(r'現有 Dtt幣: (\d+)')
+
+
+def _wallet(bot):
+    """The balance pttbbs prints on the ticket screen. There is no public
+    accessor -- PyPtt.UserField.money is the textual rank ('小康'), not a
+    number."""
+    screen = _api_lottery._enter_ticket_screen(bot, LOTTERY_BOARD)
+    _api_lottery._leave_ticket_screen(bot)
+    return int(_money_pattern.search(screen).group(1))
 
 
 @contextlib.contextmanager
@@ -147,6 +162,34 @@ def test_bet_lottery_item_past_last_option_raises(ptt_bots):
     with pytest.raises(PyPtt.exceptions.ParameterError):
         ptt2_bot.bet_lottery(board=LOTTERY_BOARD, item=len(LOTTERY_ITEMS) + 1, amount=1)
 
+    assert ptt2_bot.get_time() is not None
+
+
+def test_bet_lottery_no_money_leaves_ticket_screen(ptt_bots):
+    """Running out of money must not cost us the session.
+
+    buy_ticket_ui() reports 現金不夠 through vmsg(), which parks a bar at the
+    bottom of the screen waiting for a keypress. _leave_ticket_screen's 'q' is
+    swallowed by that bar as its "press any key", so it leaves us back on the
+    種類 prompt, still inside pttbbs' ticket() loop -- and pttbbs paints nothing
+    new on the way, so there is no screen to notice it by. Without the retry in
+    _leave_ticket_screen the (session-scoped, shared) bot stays stuck there and
+    every later call talks to the lottery menu instead of PTT."""
+    ptt1_bot, ptt2_bot = ptt_bots
+    if ptt1_bot.host != PyPtt.HOST.LOCALHOST:
+        pytest.skip('PyPttLottery is only provisioned by the LOCALHOST bootstrap')
+
+    # A single bet tops out at MAX_AMOUNT tickets, so on a wallet that rich it
+    # cannot be made unaffordable -- spend it down first.
+    if _wallet(ptt2_bot) > LOTTERY_PRICE * MAX_AMOUNT:
+        ptt2_bot.bet_lottery(board=LOTTERY_BOARD, item=1, amount=MAX_AMOUNT)
+    assert _wallet(ptt2_bot) < LOTTERY_PRICE * MAX_AMOUNT
+
+    with pytest.raises(PyPtt.exceptions.NoMoney):
+        ptt2_bot.bet_lottery(board=LOTTERY_BOARD, item=1, amount=MAX_AMOUNT)
+
+    # get_time() returns None instead of raising when it cannot reach the main
+    # menu, which is exactly what a session stuck inside ticket() looks like.
     assert ptt2_bot.get_time() is not None
 
 

--- a/tests/test_lottery.py
+++ b/tests/test_lottery.py
@@ -136,6 +136,20 @@ def test_bet_lottery_buys_exactly_the_requested_amount(ptt_bots):
     assert after[LotteryField.total] == before[LotteryField.total] + LOTTERY_PRICE * amount
 
 
+def test_bet_lottery_item_past_last_option_raises(ptt_bots):
+    """item is in range but the round has fewer options. This one only becomes
+    detectable after entering the ticket screen, so it also has to get back
+    out of it."""
+    ptt1_bot, ptt2_bot = ptt_bots
+    if ptt1_bot.host != PyPtt.HOST.LOCALHOST:
+        pytest.skip('PyPttLottery is only provisioned by the LOCALHOST bootstrap')
+
+    with pytest.raises(PyPtt.exceptions.ParameterError):
+        ptt2_bot.bet_lottery(board=LOTTERY_BOARD, item=len(LOTTERY_ITEMS) + 1, amount=1)
+
+    assert ptt2_bot.get_time() is not None
+
+
 def test_get_lottery_no_round_raises(ptt_bots):
     """A board that never had a lottery round raises NoSuchLottery."""
     ptt1_bot, ptt2_bot = ptt_bots

--- a/tests/test_lottery.py
+++ b/tests/test_lottery.py
@@ -9,14 +9,39 @@ scripts/bootstrap_local_pttbbs.py, step_lottery()); they're skipped on the
 real PTT hosts. item/amount range validation raises before any board
 navigation, so those run everywhere.
 """
+import contextlib
+
 import pytest
 
 import PyPtt
 from PyPtt import LotteryBetField, LotteryField, LotteryOptionField
+from PyPtt import _api_lottery
 
 LOTTERY_BOARD = 'PyPttLottery'
 LOTTERY_PRICE = 10
 LOTTERY_ITEMS = ('Alpha', 'Bravo', 'Charlie')
+
+
+@contextlib.contextmanager
+def _record_sends(bot):
+    """Record every (msg, return code) of connect_core.send() made inside the
+    block. send() returns -1 when no TargetUnit ever matched, i.e. the screen
+    the code was waiting for never arrived and it burned a whole
+    screen_timeout; a healthy flow returns the matched target's index."""
+    core = bot.connect_core
+    original = core.send
+    calls = []
+
+    def spy(msg, target_list, *args, **kwargs):
+        ret = original(msg, target_list, *args, **kwargs)
+        calls.append((msg, ret))
+        return ret
+
+    core.send = spy
+    try:
+        yield calls
+    finally:
+        del core.send
 
 
 def test_get_lottery_seeded_round(ptt_bots):
@@ -65,6 +90,52 @@ def test_bet_lottery_increments_sold_count(ptt_bots):
     assert sold_after == sold_before + amount
 
 
+def test_bet_lottery_never_blind_sends(ptt_bots):
+    """Every send() inside bet_lottery must match one of its own targets.
+
+    A -1 return means no TargetUnit ever matched, i.e. PyPtt sat there burning a
+    full screen_timeout on a screen it did not recognise -- and, worse, whatever
+    keys it had already queued as a `response` were replayed into a screen they
+    were not written for."""
+    ptt1_bot, ptt2_bot = ptt_bots
+    if ptt1_bot.host != PyPtt.HOST.LOCALHOST:
+        pytest.skip('PyPttLottery is only provisioned by the LOCALHOST bootstrap')
+
+    with _record_sends(ptt2_bot) as calls:
+        ptt2_bot.bet_lottery(board=LOTTERY_BOARD, item=1, amount=1)
+
+    blind = [msg for msg, ret in calls if ret == -1]
+    assert not blind, f'send() timed out on {blind!r} (all sends: {calls!r})'
+
+
+def test_bet_lottery_buys_exactly_the_requested_amount(ptt_bots):
+    """bet_lottery must buy `amount` tickets of `item` and nothing else.
+
+    pttbbs' ticket() loop reads one key at a time, so any stray key PyPtt sends
+    while it thinks it is still on the 要買多少份呢 prompt lands back on the
+    種類 prompt and silently buys extra tickets. The per-option deltas (plus
+    已下注總額, which counts every option) pin that down."""
+    ptt1_bot, ptt2_bot = ptt_bots
+    if ptt1_bot.host != PyPtt.HOST.LOCALHOST:
+        pytest.skip('PyPttLottery is only provisioned by the LOCALHOST bootstrap')
+
+    item = 1
+    amount = 2
+
+    before = ptt2_bot.get_lottery(board=LOTTERY_BOARD)
+    ptt2_bot.bet_lottery(board=LOTTERY_BOARD, item=item, amount=amount)
+    after = ptt2_bot.get_lottery(board=LOTTERY_BOARD)
+
+    def sold(lottery):
+        return [o[LotteryOptionField.sold] for o in lottery[LotteryField.options]]
+
+    expected = list(sold(before))
+    expected[item - 1] += amount
+
+    assert sold(after) == expected
+    assert after[LotteryField.total] == before[LotteryField.total] + LOTTERY_PRICE * amount
+
+
 def test_get_lottery_no_round_raises(ptt_bots):
     """A board that never had a lottery round raises NoSuchLottery."""
     ptt1_bot, ptt2_bot = ptt_bots
@@ -90,3 +161,28 @@ def test_bet_lottery_invalid_amount_raises(ptt_bots, amount):
     ptt1_bot, ptt2_bot = ptt_bots
     with pytest.raises(PyPtt.exceptions.ParameterError):
         ptt2_bot.bet_lottery(board='Test', item=1, amount=amount)
+
+
+# Deliberately last in the file: when bet_lottery does *not* clean up after
+# itself, this test leaves the shared session inside pttbbs' ticket() loop and
+# anything running after it fails too.
+def test_bet_lottery_leaves_ticket_screen_on_failure(ptt_bots, monkeypatch):
+    """A failure between entering and leaving the ticket screen must still leave
+    the ticket screen. The bot is session-scoped and shared by every test
+    (tests/conftest.py), so a bet_lottery that dies inside pttbbs' ticket() loop
+    strands the session there and takes every later test down with it."""
+    ptt1_bot, ptt2_bot = ptt_bots
+    if ptt1_bot.host != PyPtt.HOST.LOCALHOST:
+        pytest.skip('PyPttLottery is only provisioned by the LOCALHOST bootstrap')
+
+    def explode(board, screen):
+        raise RuntimeError('injected failure inside the ticket screen')
+
+    monkeypatch.setattr(_api_lottery, '_parse_lottery_screen', explode)
+    with pytest.raises(RuntimeError):
+        ptt2_bot.bet_lottery(board=LOTTERY_BOARD, item=1, amount=1)
+    monkeypatch.undo()
+
+    # get_time() returns None instead of raising when it cannot reach the main
+    # menu, which is exactly what a session stuck inside ticket() looks like.
+    assert ptt2_bot.get_time() is not None


### PR DESCRIPTION
## 問題

`bet_lottery()` 的三個 bug,都被 `send()` 逾時回 `-1` 的行為靜默吞掉,所以測試一直是綠的。

根源在於**這個函式從不檢查 `send()` 的回傳值**——它回傳的 dict 完全由送出之前算好的變數組成,所以不管流程中間錯成什麼樣,都會回報成功。

### Bug 1 — target_list 排序讓確認畫面被誤按掉

下注送出後 pttbbs 顯示 `▄▄▄▄ 請按任意鍵繼續 ▄▄▄▄`,**但同一張畫面上舊的 `要買多少份呢:3` 沒被清掉**。`_decode_screen` 依 target_list 順序比對,排在 index 0 的 `要買多少份呢` 先中,於是重送 `\x19{amount}\r`,把確認畫面誤按掉,該 send 空轉到逾時。

重排後該 send `ret=0, 0.00s`。注意錯誤分支(`現金不夠`、`板主已經停止下注了`)必須排在 `按任意鍵繼續` **之前**——`vmsg()` 的 `VMSG_MSG_FLOAT` 會把 `按任意鍵繼續` 印在同一列。

### Bug 2 — 等一個永遠不會重傳的字串

原本等 `請選擇要購買的種類`。pttbbs 對空白鍵只回**差異式重繪**,這個提示列沒變動所以不重傳;而 `_async_send` 每次 send 都重置 stream parser,只看得到本次 bytes。這個 target 從寫下來那天起就沒中過。

改等 `目前下注狀況`——`show_ticket_data()` 每次購買都會重畫下注表,所以一定在該次 bytes 裡。保留 `請選擇要購買的種類` 當 full-redraw 的 fallback。

### Bug 3 — 中途拋例外會污染共用 session

缺 `try/finally`,例外會跳過 `_leave_ticket_screen()`,把 session scope 共用的 bot 留在樂透選單,害**後續其他測試**跟著失敗。

**`_leave_ticket_screen` 的重送是這條修復的必要組成,不是額外贈品。** 實測 `NoMoney` 路徑:`q` 會被 `vmsg` bar 當成 any-key 吃掉,`Q_CALLS: [('q', -1), ('q', 0)]`;拿掉重送後 `get_time()` 回 `None`,session 直接卡死。所以只加 `try/finally` 而不重送,等於 `finally` 跑了但沒生效。上限兩次,正常路徑只送一次。

## 驗證

全部在本地 pttbbs 容器(imageptt)實跑,每次都重建乾淨容器。

**紅 → 綠**(用 `git worktree` 開一份 master 程式碼配新測試,獨立驗證過):

| | 結果 |
|---|---|
| 舊 `_api_lottery.py` + 新測試 | `2 failed, 9 passed` |
| 本 PR | `12 passed` |

紅的兩條:
- `test_bet_lottery_never_blind_sends` → `AssertionError: send() timed out on ['1', ' ']`(一條同時釘住 Bug 1 與 Bug 2)
- `test_bet_lottery_leaves_ticket_screen_on_failure` → `assert None is not None`(Bug 3)

`test_bet_lottery_no_money_leaves_ticket_screen` 專門釘住重送邏輯:拿掉 `_api_lottery.py` 的重送 → 該條紅(`assert ptt2_bot.get_time() is not None`);放回去 → 綠。

- 離線單元測試 7 檔 → 140 passed
- `flake8 PyPtt/ --count --select=E9,F63,F7,F82` → 0

## 已知限制(請 reviewer 特別看這段)

1. **`板主已經停止下注了` 分支完全沒實跑**——要板主在下注中途封盤才觸發。它與 `NoMoney` 共用同一段重送邏輯,但沒有獨立證據。
2. **`test_bet_lottery_buys_exactly_the_requested_amount` 對 Bug 1 沒有鑑別力**,修改前也是綠的。原因是 `ticket()` 每輪都 `vkey_purge()`,被重送的 `\x19{amount}\r` 只有第一個 byte 生效,不會真的多下注。保留它是當「份數/總額語意」的迴歸護欄。
3. **`no_money` 測試有順序脆弱性**:乾淨容器上初始餘額 100000、price 10,買 9999 份只要 99990 是買得起的,所以測試會先讀 ticket 畫面上的餘額,不夠才直接測、夠的話先花掉一筆再觸發。那筆會讓 `已下注總額` 大幅變動,所以它排在所有依賴 sold/total 的測試之後。日後若有人在它後面新增依賴下注數的測試會踩到。
4. **只在本地 imageptt 驗證,真實 PTT 未測。**

## 更一般的問題(不在此 PR 範圍)

這三個 bug 共同暴露:`TargetUnit` 假設「畫面上的字串唯一標識狀態」,但 pttbbs 的差異式重繪加上不清畫面,讓這個假設在多步驟流程裡並不可靠。同樣的模式可能潛伏在其他「送出後不檢查回傳碼」的 `send()` 呼叫點,值得系統性掃一遍。

## 版本

2.2.7 → 2.2.8。注意 #214 也用 2.2.8,先合併的那個佔用,之後另一個要改 2.2.9。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwUho3JuzrYGKRSyHn3kUY
