### PR TITLE
fix: mail(backup=False) 被非 bool 值繞過；reply_post 補上 backup 參數

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,6 +95,7 @@ jobs:
           tests/test_get_post_list_parser.py \
           tests/test_pyte_parity.py \
           tests/test_del_post_unit.py \
+          tests/test_backup_param.py \
           tests/test_connect_core_timeout.py \
           tests/test_incremental_parity.py \
           tests/test_parse_query_post.py \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ flake8 PyPtt/ --count --exit-zero --max-complexity=10 --max-line-length=127 --st
 ### Run tests
 Unit tests (no network required — run these during development):
 ```bash
-python -m pytest tests/test_init.py tests/test_i18n.py tests/test_exceptions.py tests/test_logger.py tests/test_parse_query_post.py tests/test_get_post_parser.py tests/test_vt100_parser.py tests/test_get_post_list_parser.py tests/test_pyte_parity.py
+python -m pytest tests/test_init.py tests/test_i18n.py tests/test_exceptions.py tests/test_logger.py tests/test_parse_query_post.py tests/test_get_post_parser.py tests/test_vt100_parser.py tests/test_get_post_list_parser.py tests/test_pyte_parity.py tests/test_backup_param.py
 ```
 
 `test_pyte_parity.py` cross-checks `VT100Parser` against the `pyte` reference VT100 emulator on captured PTT byte streams (`tests/fixtures/vt100/*.bin`). Skipped if `pyte` isn't installed.

--- a/PyPtt/PTT.py
+++ b/PyPtt/PTT.py
@@ -665,7 +665,7 @@ class API:
         return _api_get_board_list.get_board_list(self)
 
     def reply_post(self, reply_to: data_type.ReplyTo, board: str, content: str, sign_file: [str | int] = 0,
-                   aid: Optional[str] = None, index: int = 0) -> None:
+                   aid: Optional[str] = None, index: int = 0, backup: bool = True) -> None:
 
         """
         回覆文章。
@@ -677,6 +677,7 @@ class API:
             sign_file (str | int): 編號或隨機簽名檔 (x)，預設為 **0** (不選)。
             aid: 文章編號。
             index: 文章編號。
+            backup (bool): 回信給作者時是否自存底稿，預設為 True。僅在回覆類型含站內信時有作用。
 
         Returns:
             None
@@ -703,7 +704,7 @@ class API:
         參考 :ref:`回覆類型 <reply-to>`、:ref:`取得最新文章編號 <api-get-newest-index>`
         """
 
-        _api_reply_post.reply_post(self, reply_to, board, content, sign_file, aid, index)
+        _api_reply_post.reply_post(self, reply_to, board, content, sign_file, aid, index, backup)
 
     def set_board_title(self, board: str, new_title: str) -> None:
         """

--- a/PyPtt/__init__.py
+++ b/PyPtt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.3.0'
+__version__ = '2.3.1'
 __author__ = 'CodingMan'
 __email__ = 'pttcodingman@gmail.com'
 

--- a/PyPtt/_api_mail.py
+++ b/PyPtt/_api_mail.py
@@ -34,6 +34,8 @@ def mail(api,
     check_value.check_type(ptt_id, str, 'ptt_id')
     check_value.check_type(title, str, 'title')
     check_value.check_type(content, str, 'content')
+    # 沒擋型別的話，backup='False' 這種字串是 truthy，會靜靜地存底稿。
+    check_value.check_type(backup, bool, 'backup')
 
     _api_util.check_user_exist(api, ptt_id)
 

--- a/PyPtt/_api_reply_post.py
+++ b/PyPtt/_api_reply_post.py
@@ -10,7 +10,7 @@ from . import log
 
 
 def reply_post(api, reply_to: data_type.ReplyTo, board: str, content: str, sign_file, post_aid: str,
-               post_index: int) -> None:
+               post_index: int, backup: bool = True) -> None:
     _api_util.one_thread(api)
 
     if not api._is_login:
@@ -21,6 +21,8 @@ def reply_post(api, reply_to: data_type.ReplyTo, board: str, content: str, sign_
 
     check_value.check_type(board, str, 'board')
     check_value.check_type(content, str, 'content')
+    # 沒擋型別的話，backup='False' 這種字串是 truthy，會靜靜地存底稿。
+    check_value.check_type(backup, bool, 'backup')
     if post_aid is not None:
         check_value.check_type(post_aid, str, 'PostAID')
 
@@ -85,7 +87,8 @@ def reply_post(api, reply_to: data_type.ReplyTo, board: str, content: str, sign_
         connect_core.TargetUnit('請問要引用原文嗎', log_level=log.DEBUG, response='Y' + command.enter),
         connect_core.TargetUnit('採用原標題[Y/n]?', log_level=log.DEBUG, response='Y' + command.enter),
         reply_target_unit,
-        connect_core.TargetUnit('已順利寄出，是否自存底稿', log_level=log.DEBUG, response='Y' + command.enter),
+        connect_core.TargetUnit('已順利寄出，是否自存底稿', log_level=log.DEBUG,
+                                response=('Y' if backup else 'N') + command.enter),
     ]
 
     api.connect_core.send(

--- a/tests/test_backup_param.py
+++ b/tests/test_backup_param.py
@@ -1,0 +1,41 @@
+"""
+No-network unit tests for the `backup` parameter of mail / reply_post.
+
+Regression guard: `backup` used to skip check_type, so a truthy non-bool
+like the string 'False' silently answered 是否自存底稿 with 'y' and left a
+backup in the sender's mailbox. `reply_post` had no `backup` parameter at
+all and always answered 'Y'.
+"""
+import threading
+
+import pytest
+
+import PyPtt
+from PyPtt import _api_mail, _api_reply_post
+
+NON_BOOLS = ['False', 'false', '0', 0, 1, None]
+
+
+class _StubAPI:
+    """Just enough of PyPtt.API to reach the parameter checks."""
+    _thread_id = threading.get_ident()
+    _is_login = True
+    is_registered_user = True
+
+
+@pytest.mark.parametrize('backup', NON_BOOLS)
+def test_mail_non_bool_backup_raises(backup):
+    with pytest.raises(TypeError):
+        _api_mail.mail(_StubAPI(), 'someone', 'title', 'content', 0, backup)
+
+
+@pytest.mark.parametrize('backup', NON_BOOLS)
+def test_reply_post_non_bool_backup_raises(backup):
+    with pytest.raises(TypeError):
+        _api_reply_post.reply_post(_StubAPI(), PyPtt.ReplyTo.BOARD, 'Test', 'content', 0, None, 1, backup)
+
+
+def test_reply_post_exposes_backup():
+    """回信給作者時的自存底稿以前寫死 'Y'，關不掉。"""
+    import inspect
+    assert inspect.signature(PyPtt.API.reply_post).parameters['backup'].default is True


### PR DESCRIPTION
## 問題

收到回報「寄信時 `backup` 代入 `False`，信箱還是留下備份」。

`mail()` 的 `backup` 是**唯一沒過 `check_value.check_type()`** 的參數，`_api_mail.py` 直接用 `('y' if backup else 'n')`。所以任何 truthy 的非 bool 值 —— `'False'`、`'0'`、`'no'` 這種從 env / JSON config / argparse / CLI 進來的字串 —— 都會靜靜地存底稿。使用者以為關掉了，實際上還是備份。

真 PTT 實測（寄給第三方帳號，量自己信箱的增量）：

| 傳入值 | 信箱增量 | |
|---|---|---|
| `backup=False` | 0 | ✅ |
| `backup=True` | 1 | ✅ 對照組 |
| `backup='False'` | 1 | ❌ bug |

追查過程中確認過的其他變因（都不是原因）：`sign_file=0/1/'x'` 全部 DELTA=0；`Service` 與 MCP 的參數傳遞也都正確。

## 順手修掉的另一半

`_api_reply_post.py` 把「已順利寄出，是否自存底稿」**寫死 `response='Y'`**，而 `reply_post()` 根本沒開 `backup` 參數 —— 回信給作者時一定留備份、關不掉。

## 改動

- `_api_mail.py` — 補 `check_value.check_type(backup, bool, 'backup')`，跟其他參數一致，非 bool 直接丟 `TypeError` 而不是默默備份
- `_api_reply_post.py` — 開 `backup` 參數（預設 `True`，維持舊行為），`'Y'` → `('Y' if backup else 'N')`，補同樣的型別檢查
- `PTT.py` — `reply_post` 簽章、docstring、傳參
- `tests/test_backup_param.py` — 新增，無網路（stub 掉 `API` 只跑到參數檢查），13 cases 涵蓋兩支 API
- `deploy.yml` / `CLAUDE.md` — 加進 CI 清單
- 版號 2.3.0 → 2.3.1

## 驗證

```
本地 pttbbs（直接數收件人信箱的實體檔案）
  reply_post backup=False   mail_files 1 -> 1  DELTA=0  ✅
  reply_post backup=True    mail_files 1 -> 2  DELTA=1  ✅

新測試 stash 掉修復後 → 6 failed（確認擋得住）
CI 全套 unit → 510 passed
flake8 E9,F63,F7,F82 → 0
```

## 為什麼 CI 之前沒抓到

`backup` 這條路 CI 完全沒守。唯一碰到它的 `test_mail_send_and_del.py` 是要帳密的整合測試，而且只測 `backup=True`。這個 PR 補的是 CI 跑得動的無網路版本。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwUho3JuzrYGKRSyHn3kUY