### PR TITLE
fix: 移除密碼 8 字元截斷，因應 pttbbs 長密碼支援 (#112)

### DIFF
--- a/PyPtt/__init__.py
+++ b/PyPtt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.3.2'
+__version__ = '2.3.3'
 __author__ = 'CodingMan'
 __email__ = 'pttcodingman@gmail.com'
 

--- a/PyPtt/_api_change_pw.py
+++ b/PyPtt/_api_change_pw.py
@@ -13,8 +13,6 @@ def change_pw(api, new_password: str) -> None:
 
     log.logger.info(i18n.change_pw)
 
-    new_password = new_password[:8]
-
     cmd_list = []
     cmd_list.append(command.go_main_menu)
     cmd_list.append('U')
@@ -29,9 +27,12 @@ def change_pw(api, new_password: str) -> None:
         connect_core.TargetUnit('設定聯絡信箱後才能修改密碼', exceptions_=exceptions.SetContactMailFirst()),
         connect_core.TargetUnit('您輸入的密碼不正確', exceptions_=exceptions.WrongPassword()),
         connect_core.TargetUnit('請您確定(Y/N)？', response='Y' + command.enter),
-        connect_core.TargetUnit('檢查新密碼', response=new_password + command.enter, max_match=1),
-        connect_core.TargetUnit('設定新密碼', response=new_password + command.enter, max_match=1),
-        connect_core.TargetUnit('輸入原密碼', response=api._ptt_pw + command.enter, max_match=1),
+        # 只比對「新密碼」/「原密碼」, 不含前後綴與冒號: 正式站目前是「請設定新密碼：」
+        # 「請檢查新密碼：」「請輸入原密碼：」(全形冒號), pttbbs #112 之後上游改成兩步同名的
+        # 「新密碼:」(半形), 兩種寫法都涵蓋。新密碼要吃設定與確認兩次, 故 max_match=2。
+        # 「新密碼」必須排在「原密碼」前面: 新版輸入完原密碼後該行仍留在畫面上, 兩者會同時出現。
+        connect_core.TargetUnit('新密碼', response=new_password + command.enter, max_match=2, secret=True),
+        connect_core.TargetUnit('原密碼', response=api._ptt_pw + command.enter, max_match=1, secret=True),
         connect_core.TargetUnit('設定個人資料與密碼', break_detect=True)
     ]
 

--- a/PyPtt/_api_give_money.py
+++ b/PyPtt/_api_give_money.py
@@ -78,7 +78,7 @@ def give_money(api, ptt_id: str, money: int, red_bag_title: str, red_bag_content
         connect_core.TargetUnit('按任意鍵繼續', break_detect=True),
         edit_red_bag_target,
         connect_core.TargetUnit('要修改紅包袋嗎', response=command.enter),
-        connect_core.TargetUnit('完成交易前要重新確認您的身份', response=api._ptt_pw + command.enter),
+        connect_core.TargetUnit('完成交易前要重新確認您的身份', response=api._ptt_pw + command.enter, secret=True),
         connect_core.TargetUnit('他是你的小主人，是否匿名？', response='n' + command.enter),
         connect_core.TargetUnit('要給他多少Ptt幣呢?', response=command.tab + str(money) + command.enter),
         connect_core.TargetUnit('這位幸運兒的id', response=ptt_id + command.enter),

--- a/PyPtt/_api_loginout.py
+++ b/PyPtt/_api_loginout.py
@@ -68,7 +68,9 @@ def login(api, ptt_id: str, ptt_pw: str, kick_other_session: bool) -> None:
         api.process_picks = int(pattern.search(screen).group(0))
 
     ptt_id = ptt_id[:12].strip()
-    ptt_pw = ptt_pw[:8].strip()
+    # 不截斷密碼: 舊版 PTT 由 server 端忽略第 8 字之後的部分, 新版 (pttbbs #112, bcrypt)
+    # 則支援 72 字元, 兩邊都必須送出完整密碼才會正確。
+    ptt_pw = ptt_pw.strip()
 
     api.ptt_id = ptt_id
     api._ptt_pw = ptt_pw


### PR DESCRIPTION
## 背景

[pttbbs UPDATING](https://github.com/ptt/pttbbs/blob/master/UPDATING) 於 2026-07-28 記錄：密碼上限由 8 字元（`PASSLEN 14`, DES）改為 72 字元（`PW_PLAIN_LEN`, bcrypt），並把新密碼輸入/確認的 UI 合併成 `get_new_passwd()`。

PyPtt 在 `login` 與 `change_pw` 兩處都把密碼截斷到 8 字元：

- 正式站上線後，設 9 字以上密碼的帳號將**完全無法登入**
- `change_pw` 會靜默把密碼設成截斷後的短密碼，並寫回 `api._ptt_pw`，連帶影響 `give_money` 的身份重新確認
- `ptt_pw[:8].strip()` 的 strip 在截斷之後，密碼結尾有空白會被偷改 — 這是今天就存在的 bug

## 改動

| 檔案 | 改動 |
|---|---|
| `_api_loginout.py` | 移除 `ptt_pw[:8]`。舊站由 server 端忽略第 8 字之後，新舊站都必須送完整密碼 |
| `_api_change_pw.py` | 移除 `new_password[:8]`；target 由 3 條收成 2 條 |
| `_api_give_money.py` | 身份重新確認補 `secret=True` |
| `__init__.py` | 版號 2.3.2 → 2.3.3（本地與 PyPI 同版，`Forget to update the version?` 會擋） |

### 為什麼 target 只比對「新密碼」/「原密碼」

**正式站字串與 pttbbs 上游原始碼已經分岔**，而且差異點正好落在這些 target 上：

| | 原密碼 | 新密碼 |
|---|---|---|
| 正式站 ptt.cc（真機實測） | `請輸入原密碼：` | `請設定新密碼：` / `請檢查新密碼：` |
| pttbbs 上游 改版前 | `原密碼：` | `新密碼：` |
| pttbbs 上游 改版後（`2db36a60`） | `原密碼:` | `新密碼:`（兩步同名，半形） |

初版曾照上游新字串加了 `'新密碼:'`／`'原密碼:'` 兩條半形 target 想做前瞻相容，真機驗證後證實是**永遠不會觸發的死碼** —— 正式站連改版前的字串都跟上游不同，沒理由相信它改版後會採用上游寫法。

改為只比對最短共同關鍵詞、不含前後綴與冒號，兩種寫法都涵蓋。`新密碼` 需吃設定與確認兩次故 `max_match=2`；`新密碼` 必須排在 `原密碼` 前面，因為上游新版輸入完原密碼後該行仍留在畫面上，兩者會同時出現（`connect_core.py:269` 按 list 順序取第一個 match）。

## 驗證（真實 PTT）

| 項目 | 結果 |
|---|---|
| `test_change_pw.py` | 1 passed |
| `test_give_money.py` | 1 passed |
| `'原密碼'` 觸發 | 1 次，命中「請輸入原密碼：」 |
| `'新密碼'` 觸發 | 2 次，命中「請設定新密碼：」「請檢查新密碼：」 |
| max_match 用盡後 | 正確落到 `請您確定(Y/N)？` → Y → break_detect |
| 結束畫面誤吃 match | 無（逐行 grep 四個畫面快照，成功畫面不含相關字樣） |
| DEBUG log 密碼明文 | 改動前 3 次 → 改動後 0 次 |
| unit tests | 221 passed |
| flake8（CI 的 `--select=E9,F63,F7,F82`） | 0 問題，對照 HEAD 基線無新增 |

## 未驗證

- **9 字元以上密碼的登入行為**：測試帳號密碼恰為 8 字元，且正式站尚未部署 bcrypt，無從設定長密碼。要等 PTT 實際上線才驗得了。
- `test_login_logout.py` 設計上對真實 PTT 一律 skip；但 `test_change_pw` 能過即代表 conftest 登入成功，登入路徑間接驗到。

## 刻意沒做

- 72 字元上限驗證 —— 正式站沒上線，現在加只會擋到還在用舊站的使用者
- 新增失敗畫面（「密碼不可以跟帳號一樣」「密碼至少要有 N 個字元」「兩次輸入結果不符合」）的具名例外 —— 目前會落到既有的 `UnknownError(ori_screen)`，畫面本身就寫了原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
