### PR TITLE
fix: 靜默假成功、長度上限差 1、站名常數不同步（對照 pttbbs 原始碼盤點）

### DIFF
--- a/PyPtt/__init__.py
+++ b/PyPtt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.3.3'
+__version__ = '2.3.4'
 __author__ = 'CodingMan'
 __email__ = 'pttcodingman@gmail.com'
 

--- a/PyPtt/_api_del_post.py
+++ b/PyPtt/_api_del_post.py
@@ -15,7 +15,12 @@ from . import screens
 
 # pttbbs input fields cap length in bytes (Big5: 2 bytes per Chinese
 # character), not in Python characters.
-_BAD_POST_REASON_MAX_BYTES = 50
+# mbbsd/assess.c:71 getdata(..., reason, 50, DOECHO) -> len=50 -> vtuikit.c's
+# getdata() only accepts len-1 bytes, and vkey_purge() (vtuikit.c:1409-1415)
+# clears the whole input queue if the last accepted byte lands at iend ==
+# len-2 with a Big5 lead byte (>0x80) still queued right after it -- so the
+# safe cap is len-2, not len-1.
+_BAD_POST_REASON_MAX_BYTES = 48
 
 # --- del_post's `reason` field (annotates the title shown after a
 # moderator deletes another user's post) ---
@@ -24,7 +29,8 @@ _BAD_POST_REASON_MAX_BYTES = 50
 # (pttbbs mbbsd/bbs.c, del_post()'s SAFE_ARTICLE_DELETE branch) in a
 # `char reason[PROPER_TITLE_LEN]` buffer; PROPER_TITLE_LEN is 42
 # (pttbbs include/common.h), so the whole title -- prefix *and* PyPtt's
-# reason together -- is capped at 41 Big5 bytes, not python characters.
+# reason together -- is capped at 40 Big5 bytes, not python characters
+# (len-2, see the vkey_purge() mechanism below).
 # PyPtt answers the prompt with Ctrl-E (jump to the end of the prefilled
 # text) plus a leading space plus `reason`, so the byte budget actually
 # left for `reason` depends on how long the moderator's and the post
@@ -34,8 +40,11 @@ _BAD_POST_REASON_MAX_BYTES = 50
 # Verified live against a local pttbbs (bbsdocker/imageptt rebuilt with
 # SAFE_ARTICLE_DELETE enabled -- the stock image ships with that feature
 # #define'd out and never offers this prompt at all):
-#   - exactly at the budget: reason is accepted in full, title not
-#     truncated.
+#   - within the safe budget: reason is accepted in full, title not
+#     truncated. (One prior run that landed exactly on the old,
+#     off-by-one budget only happened not to trip the bug below because
+#     the overflow byte's low bit was < 0x80 -- that was luck, not a
+#     safe boundary; see the mechanism below for why.)
 #   - 1 byte over budget, ASCII-only overflow: pttbbs silently truncates
 #     to fit (title is just missing the last character).
 #   - 1 byte over budget, where the overflow splits a double-byte Big5
@@ -44,7 +53,14 @@ _BAD_POST_REASON_MAX_BYTES = 50
 #     a clean failure -- this is the "刪文失敗" a caller with a too-long
 #     reason actually experiences.
 # PyPtt must reject before sending in both cases.
-_REASON_TITLE_BUFFER_BYTES = 41  # PROPER_TITLE_LEN(42) - 1 byte reserved for the NUL terminator
+#
+# mbbsd/bbs.c:3311,3387 getdata(..., reason, PROPER_TITLE_LEN, ...);
+# include/common.h:193 PROPER_TITLE_LEN 42 -> len=42 -> vtuikit.c's
+# getdata() only accepts len-1 bytes, and vkey_purge() (vtuikit.c:1409-1415)
+# clears the whole input queue if the last accepted byte lands at
+# iend == len-2 with a Big5 lead byte still queued right after it -- so the
+# safe cap is len-2, not len-1.
+_REASON_TITLE_BUFFER_BYTES = 40  # PROPER_TITLE_LEN(42) - 2, see vkey_purge() note above
 _REASON_PREFIX_FIXED_BYTES = 13  # Big5 bytes of "(已被刪除) <>", the literal part of "(已被%s刪除) <%s>"
 # A rough, moderator/author-id-independent ceiling: the most bytes `reason`
 # could ever fit under, i.e. the budget if both PTT ids were the shortest

--- a/PyPtt/_api_mail.py
+++ b/PyPtt/_api_mail.py
@@ -33,6 +33,17 @@ def mail(api,
 
     check_value.check_type(ptt_id, str, 'ptt_id')
     check_value.check_type(title, str, 'title')
+    # mbbsd/mail.c:774-775 char tmp_title[STRLEN-20]; include/pttstruct.h:313
+    # STRLEN 80 -> len=60 -> vtuikit.c's getdata() only accepts len-1 bytes,
+    # and vkey_purge() clears the whole input queue if the overflow byte
+    # lands right after a Big5 lead byte -- so the safe cap is len-2 = 58.
+    try:
+        encoded_title = title.encode('big5uao')
+    except UnicodeEncodeError as e:
+        raise exceptions.ParameterError(
+            f'title contains a character that cannot be encoded in Big5: {e}') from e
+    if len(encoded_title) > 58:
+        raise exceptions.ParameterError('title must not exceed 58 bytes')
     check_value.check_type(content, str, 'content')
     # 沒擋型別的話，backup='False' 這種字串是 truthy，會靜靜地存底稿。
     check_value.check_type(backup, bool, 'backup')
@@ -117,7 +128,6 @@ def mail(api,
 # ※ 發信站: 批踢踢實業坊(ptt.cc)
 # ◆ From: 220.142.14.95
 content_start = '───────────────────────────────────────'
-content_end = '--\n※ 發信站: 批踢踢實業坊(ptt.cc)'
 content_ip_old = '◆ From: '
 
 mail_author_pattern = re.compile(r'作者  (.+)')
@@ -234,7 +244,7 @@ def get_mail(api, index: int, search_type: Optional[data_type.SearchType] = None
 
     # 紅包偵測
     red_envelope = False
-    if content_end not in origin_mail and 'Ptt幣的大紅包喔' in origin_mail:
+    if not any(EC in origin_mail for EC in screens.Target.content_end_list) and 'Ptt幣的大紅包喔' in origin_mail:
         mail_content = mail_content.strip()
         red_envelope = True
 
@@ -248,7 +258,8 @@ def get_mail(api, index: int, search_type: Optional[data_type.SearchType] = None
         # 非紅包開始解析 ip 與 地區
 
         ip_line_list = origin_mail.split('\n')
-        ip_line = [x for x in ip_line_list if x.startswith(content_end[3:])]
+        ip_line = [x for x in ip_line_list
+                   if any(x.startswith(EC[3:]) for EC in screens.Target.content_end_list)]
 
         if len(ip_line) == 0:
             # 沒 ip 就沒地區

--- a/PyPtt/_api_post.py
+++ b/PyPtt/_api_post.py
@@ -149,6 +149,18 @@ def post(api, board: str, title: str, content: str, title_index: int, sign_file:
     check_value.check_type(content, str, 'content')
     check_value.check_type(anonymous, bool, 'anonymous')
 
+    # mbbsd/bbs.c:1360-1365 caps the title field at DISP_TTLEN=46 cells on an
+    # 80-col screen; mbbsd/vtuikit.c:1409-1415's vkey_purge() clears the whole
+    # input queue one byte earlier than that, eating PyPtt's batched Enter and
+    # follow-up commands -- so the safe limit is 46-2=44 Big5 bytes, not 45.
+    try:
+        encoded_title = title.encode('big5uao')
+    except UnicodeEncodeError as e:
+        raise exceptions.ParameterError(
+            f'title contains a character that cannot be encoded in Big5: {e}') from e
+    if len(encoded_title) > 44:
+        raise exceptions.ParameterError('title must not exceed 44 bytes')
+
     if str(sign_file).lower() not in sign_file_list:
         raise exceptions.ParameterError(f'wrong parameter sign_file: {sign_file}')
 
@@ -205,9 +217,12 @@ def post(api, board: str, title: str, content: str, title_index: int, sign_file:
         connect_core.TargetUnit('確定[y/N]', response='y' + command.enter, max_match=1),
         connect_core.TargetUnit('x=隨機', response=str(sign_file) + command.enter),
     ]
-    api.connect_core.send(
+    index = api.connect_core.send(
         cmd,
         target_list,
         screen_timeout=api.config.screen_post_timeout)
+    if index < 0:
+        ori_screen = api.connect_core.get_screen_queue()[-1]
+        raise exceptions.UnknownError(ori_screen)
 
     log.logger.info(i18n.post, '...', i18n.success)

--- a/PyPtt/_api_reply_post.py
+++ b/PyPtt/_api_reply_post.py
@@ -16,6 +16,9 @@ def reply_post(api, reply_to: data_type.ReplyTo, board: str, content: str, sign_
     if not api._is_login:
         raise exceptions.RequireLogin(i18n.require_login)
 
+    if not api.is_registered_user:
+        raise exceptions.UnregisteredUser(lib_util.get_current_func_name())
+
     if not isinstance(reply_to, data_type.ReplyTo):
         raise TypeError('ReplyTo must be data_type.ReplyTo')
 
@@ -79,6 +82,12 @@ def reply_post(api, reply_to: data_type.ReplyTo, board: str, content: str, sign_
         connect_core.TargetUnit('任意鍵繼續', break_detect=True),
         connect_core.TargetUnit('◆ 很抱歉, 此文章已結案並標記, 不得回應', log_level=log.INFO,
                                 exceptions_=exceptions.CantResponse()),
+        # mbbsd/bbs.c:1736 "此篇文章已結案, 是否真的要回應?(y/N)" -- closed but not
+        # marked, distinct from the CantResponse case above; answering 'y'
+        # lets the reply continue normally.
+        connect_core.TargetUnit('是否真的要回應', log_level=log.INFO, response='y' + command.enter),
+        # mbbsd/bbs.c:1742-1745 BRD_NOREPLY board: "...本板不開放回覆文章...".
+        connect_core.TargetUnit('不開放回覆文章', log_level=log.INFO, exceptions_=exceptions.CantResponse()),
         connect_core.TargetUnit('(E)繼續編輯 (W)強制寫入', log_level=log.INFO, response='W' + command.enter),
         # max_match=1 是防禦性上限，理由同 _api_mail.py。三種 reply_to（BOARD / MAIL /
         # BOARD_MAIL）都對真 PTT 實測過，這個 target 一次都沒命中，目前執行不到。
@@ -93,9 +102,12 @@ def reply_post(api, reply_to: data_type.ReplyTo, board: str, content: str, sign_
                                 response=('Y' if backup else 'N') + command.enter),
     ]
 
-    api.connect_core.send(
+    index = api.connect_core.send(
         cmd,
         target_list,
         screen_timeout=api.config.screen_long_timeout)
+    if index < 0:
+        ori_screen = api.connect_core.get_screen_queue()[-1]
+        raise exceptions.UnknownError(ori_screen)
 
     log.logger.info(reply_msg, '...', i18n.success)

--- a/PyPtt/_api_set_board_title.py
+++ b/PyPtt/_api_set_board_title.py
@@ -22,10 +22,34 @@ def set_board_title(api, board: str, new_title: str) -> None:
     check_value.check_type(board, str, 'board')
     check_value.check_type(new_title, str, 'new_title')
 
+    # mbbsd/board.c:641 vgetstr(genbuf, BTLEN-16, ...) with BTLEN=48 gives
+    # len=32; vtuikit.c:1409-1415's vkey_purge() clears the input queue one
+    # byte early, so the safe limit is 32-2=30 Big5 bytes, not 31.
+    try:
+        encoded_new_title = new_title.encode('big5uao')
+    except UnicodeEncodeError as e:
+        raise exceptions.ParameterError(
+            f'new_title contains a character that cannot be encoded in Big5: {e}') from e
+    if len(encoded_new_title) > 30:
+        raise exceptions.ParameterError('new_title must not exceed 30 bytes')
+
     _api_util.check_board(
         api,
         board,
         check_moderator=True)
+
+    # check_board() above calls get_board_info(get_post_kind=False) (to look
+    # up the moderator list) whenever the board isn't already cached, and
+    # that helper reads the board's "《board》看板設定" info screen but never
+    # dismisses its trailing "[按任意鍵繼續]" prompt. Left alone, the 'I'
+    # below lands on that prompt instead of the board's article-list screen:
+    # it gets consumed as the "any key" dismissal, so the following ctrl_p
+    # is read as the article-list's own "[Ctrl-P]發表文章" shortcut and the
+    # whole command ends up composing a new post instead of opening board
+    # settings. Verified live against a moderated board: without this
+    # re-navigation the send always lands in the article editor; with it,
+    # the confirmation targets below match every time (8/8 in local testing).
+    _api_util.goto_board(api, board)
 
     cmd_list = []
     cmd_list.append('I')
@@ -42,7 +66,10 @@ def set_board_title(api, board: str, new_title: str) -> None:
         connect_core.TargetUnit('◆ 未改變任何設定', break_detect=True),
     ]
 
-    api.connect_core.send(
+    index = api.connect_core.send(
         cmd,
         target_list,
         screen_timeout=api.config.screen_long_timeout)
+    if index < 0:
+        ori_screen = api.connect_core.get_screen_queue()[-1]
+        raise exceptions.UnknownError(ori_screen)

--- a/tests/test_del_post_unit.py
+++ b/tests/test_del_post_unit.py
@@ -10,11 +10,11 @@ from PyPtt import _api_del_post
 
 class TestCheckBadPostReason:
     def test_within_limit_ok(self):
-        _api_del_post._check_bad_post_reason('測' * 25)  # 50 bytes, exactly at the limit
+        _api_del_post._check_bad_post_reason('測' * 24)  # 48 bytes, exactly at the limit
 
     def test_over_limit_raises(self):
         with pytest.raises(PyPtt.exceptions.ParameterError):
-            _api_del_post._check_bad_post_reason('測' * 25 + 'x')  # 51 bytes
+            _api_del_post._check_bad_post_reason('測' * 24 + 'x')  # 49 bytes, 1 over the limit
 
     def test_control_char_raises(self):
         with pytest.raises(PyPtt.exceptions.ParameterError):
@@ -24,18 +24,18 @@ class TestCheckBadPostReason:
 class TestCheckReasonStatic:
     """`_check_reason` is the early, post_info-independent guard: control
     chars, Big5-encodability, and a rough ceiling (_REASON_MAX_POSSIBLE_BYTES
-    == 41 - 13 - 1 - 1 - 1 == 25 bytes) that assumes the shortest possible
+    == 40 - 13 - 1 - 1 - 1 == 24 bytes) that assumes the shortest possible
     (1-byte) moderator/author PTT ids -- the most bytes a reason could ever
     fit under any real id pair. It therefore never rejects a reason that
     might be legal once the real ids are known; that exact, smaller,
     id-dependent budget is _check_reason_budget's job (see below)."""
 
     def test_within_rough_ceiling_ok(self):
-        _api_del_post._check_reason('測' * 12 + 'x')  # 25 bytes, exactly the rough ceiling
+        _api_del_post._check_reason('測' * 12)  # 24 bytes, exactly the rough ceiling
 
     def test_over_rough_ceiling_raises(self):
         with pytest.raises(PyPtt.exceptions.ParameterError):
-            _api_del_post._check_reason('測' * 12 + 'xx')  # 26 bytes
+            _api_del_post._check_reason('測' * 12 + 'x')  # 25 bytes, 1 over the ceiling
 
     def test_control_char_raises(self):
         with pytest.raises(PyPtt.exceptions.ParameterError):
@@ -49,21 +49,21 @@ class TestCheckReasonStatic:
 class TestCheckReasonBudget:
     """`_check_reason_budget` is the exact, post_info-dependent guard: reason
     gets appended, after a leading space, to pttbbs's prefilled
-    "(已被<moderator_id>刪除) <author_id>" title inside a 41-Big5-byte buffer
+    "(已被<moderator_id>刪除) <author_id>" title inside a 40-Big5-byte buffer
     (_REASON_TITLE_BUFFER_BYTES). Budget for a 9-char/9-char id pair (e.g.
     pypttbot1 deleting pypttbot2's post, as used in the local imageptt
-    integration tests) is 41 - 13 - 9 - 9 - 1 == 9 bytes -- confirmed live
+    integration tests) is 40 - 13 - 9 - 9 - 1 == 8 bytes -- confirmed live
     against a local pttbbs rebuilt with SAFE_ARTICLE_DELETE enabled."""
 
     MOD_ID = 'pypttbot1'
     AUTHOR_ID = 'pypttbot2'
 
     def test_within_limit_ok(self):
-        _api_del_post._check_reason_budget('測測測測x', self.MOD_ID, self.AUTHOR_ID)  # 9 bytes, exactly at the limit
+        _api_del_post._check_reason_budget('測測測測', self.MOD_ID, self.AUTHOR_ID)  # 8 bytes, exactly at the limit
 
     def test_over_limit_by_one_byte_raises(self):
         with pytest.raises(PyPtt.exceptions.ParameterError):
-            _api_del_post._check_reason_budget('測測測測測', self.MOD_ID, self.AUTHOR_ID)  # 10 bytes
+            _api_del_post._check_reason_budget('測測測測x', self.MOD_ID, self.AUTHOR_ID)  # 9 bytes, 1 over the limit
 
     def test_over_limit_ascii_raises(self):
         with pytest.raises(PyPtt.exceptions.ParameterError):
@@ -71,8 +71,8 @@ class TestCheckReasonBudget:
 
     def test_budget_shrinks_with_longer_ids(self):
         """A 12-char/12-char id pair (PTT's real max, IDLEN==12) leaves only
-        3 bytes of budget -- a reason that fits the 9/9 pair above no
+        2 bytes of budget -- a reason that fits the 9/9 pair above no
         longer fits."""
         with pytest.raises(PyPtt.exceptions.ParameterError):
             _api_del_post._check_reason_budget('測測測測x', 'a' * 12, 'b' * 12)
-        _api_del_post._check_reason_budget('x', 'a' * 12, 'b' * 12)  # 1 byte still fits the 3-byte budget
+        _api_del_post._check_reason_budget('x', 'a' * 12, 'b' * 12)  # 1 byte still fits the 2-byte budget


### PR DESCRIPTION
對照 [pttbbs](https://github.com/ptt/pttbbs) 原始碼全面盤點 PyPtt 的硬編碼假設後，修掉一批 correctness 問題。接續 #219。

**字串類假設刻意不動** —— 正式站 ptt.cc 是自己的 fork，畫面字串與上游已分岔（#219 已實證：正式站 `請輸入原密碼：` vs 上游 `原密碼：`），照上游寫死反而會錯。

## 1. 靜默假成功

`post` / `reply_post` / `set_board_title` 都忽略 `connect_core.send()` 的 `-1`，下一行直接 log success。PTT 一旦停在未涵蓋的畫面，這三支會等滿 timeout 然後**回報成功，實際上什麼都沒存、session 還留在未知畫面**。

三處補上 `index < 0` → `raise UnknownError`（帶最後畫面）。

`reply_post` 另補兩條缺失的 target 與 `is_registered_user` 前置檢查：

| 畫面 | 上游依據 | 現況 |
|---|---|---|
| 已結案**未**標記的 y/N 提示 | `bbs.c:1736` | 既有 target 只擋了「已結案**並**標記」 |
| `BRD_NOREPLY` 看板 | `bbs.c:1742-1745` | 無 target |
| 無發文權（零畫面變化） | `bbs.c:1728` `return DONOTHING` | 只能靠 -1 檢查 |

`is_registered_user` 順帶堵住上游 `69e1ecf` 新增的 `!HasSendMailUserPerm()` 分支 —— 該分支的兩選項選單（只有 `(F)看板 (Q)取消`）會讓 PyPtt 送出的 `'M'` 落入 `default: do_post()`，**把私信回覆變成公開發文**。

## 2. 長度上限：安全值是 `len − 2`，不是 `len − 1`

`getdata(..., len, ...)` 實際可輸入 `len−1` bytes（`vtuikit.c:1404`）；但 `vtuikit.c:1409-1415` 的 `vkey_purge()` 會在 `iend == len-2` 且下一 byte >0x80（Big5 中文字前半）時**清空整個輸入佇列**。PyPtt 一律把「欄位內容 + Enter + 後續按鍵」批次成一次 `send()`，佇列必有後續 byte，所以 **Enter 與其後全部指令會一起被吃掉**。

`_api_del_post.py:39-45` 既有註解記錄的本地實測 hang，正是這個機制。

| PyPtt | 舊 | 新 | 上游依據 |
|---|---|---|---|
| `_api_del_post.py` 惡退原因 | 50 | **48** | `assess.c:71` |
| `_api_del_post.py` reason budget | 41 | **40** | `PROPER_TITLE_LEN 42` |
| `_api_post.py` title | 無 | **44** | `bbs.c:1360-1365`, `DISP_TTLEN 46` |
| `_api_mail.py` title | 無 | **58** | `mail.c:774`, `STRLEN-20` |
| `_api_set_board_title.py` new_title | 無 | **30** | `board.c:641`, `BTLEN-16` |

新檢查沿用 `_api_del_post.py:86-95` 既有慣例（先 `try/except UnicodeEncodeError` 轉 `ParameterError` 再比長度）—— 送出路徑是 utf-8 `'replace'`，改動前不會拋例外，不能讓裸的 `UnicodeEncodeError` 洩漏出去。

## 3. `_api_mail.py` 站名常數不同步

模組層自帶只涵蓋 ptt.cc 的 `content_end`，未與 `screens.Target.content_end_list`（涵蓋 ptt2 / pttdocker）同步 → **PTT2 與 localhost 上 `get_mail()` 的 `ip` 與 `location` 恆為 None**，整合測試跑在容器上時這兩欄等於沒測。三處使用點改走 `content_end_list`。

## 4. `set_board_title` 板主路徑（由 §1 的 -1 檢查照出來）

`check_board()` 只在看板**未快取**時呼叫 `get_board_info()`，而後者讀完看板設定畫面後**不收尾端的 `[按任意鍵繼續]`**，於是後續按鍵整條錯位：

| 送出 | 預期 | 實際 |
|---|---|---|
| `'I'` | 進看板資訊 | 被當任意鍵 dismiss |
| `ctrl_p` | 板務選單 | 觸發 `[Ctrl-P]發表文章` |
| `'b'` | 修改中文敘述 | 打進發文「種類：」欄 |
| `backspace*31` + title + `enter*2` | 改標題 | 打進**文章標題欄**，進編輯器 |

修法：`check_board()` 後補一次 `goto_board()` 重新導航，鍵序與 target_list 不動。

**已枚舉 `check_board()` 全部 10 個呼叫點**：其餘 9 處都已在 `check_board` 之後呼叫 `goto_board`（`_api_comment.py` 是在實際送鍵的 `_comment()` 開頭），只有 `set_board_title` 的 `goto_board` 在 `check_board` **之前**，是唯一受影響者。

## 驗證

- **232 unit tests passed**；flake8（CI 的 `--select=E9,F63,F7,F82`）0 問題
- **本地 pttbbs 容器**（每次全新 podman + bootstrap）：`test_set_board_title` 2 passed、`test_reply_post` / `test_post` / `test_mail_send_and_del` 各 1 passed
- `set_board_title` 修法**分別驗證「看板未快取」與「已快取」兩種狀態**皆成功（bug 只在未快取時觸發，只驗一種等於驗一半）
- `reply_post(reply_to=MAIL)` 手動實跑確認命中 `break_detect`、未被新的 -1 檢查誤擋
- 五個長度常數由獨立驗收**對照 pttbbs 原始碼重新推導**，不採信交付說明與既有註解
- `tests/test_del_post_unit.py` 同步到新常數，並確認三組都保留「邊界值通過 + 邊界值+1 raise」兩側

版號 2.3.3 → 2.3.4（PyPI 已發佈 2.3.3）。

## 未驗證 / 刻意不做

- 真實 PTT 的整合測試（會發文寄信，刻意保留給人工決定）
- `reply_post` 新增兩條 target 的實際觸發（需無發文權 / `BRD_NOREPLY` 環境）
- `_api_comment.py` 的四個推文長度常數（32 / 43−id / 46 / 58−id）：獨立核算後確認**全都 ≤ 安全上限，不是 bug**，只是比實際可容納量少 1–2 bytes。未改動
- `_api_mail.py` 的 -1 檢查：該處 `break_detect_after_send=True` 讓成功路徑本身就回 -1，重做成功判定是另一件事
- 小天使匿名推文（`PLAY_ANGEL`）可能吃掉推文第一個字：上游預設關閉，無法判定 ptt.cc build 是否開啟，證據不足未動

## 已知的既有問題（不在本 PR 範圍）

`_api_get_board_info.py` 會把看板列表的顯示前綴（`測試 ◎`）誤當成 `mandarin_des` 的值讀回。對同一容器反覆跑 `set_board_title` 會讓標題不斷疊加，最後撞到本 PR 新加的 30 bytes 檢查。容器測試因此必須每次重建。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
