### PR TITLE
fix: 相容 websockets 14~17（http 模組移除、.closed 消失）

### DIFF
--- a/PyPtt/__init__.py
+++ b/PyPtt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.3.4'
+__version__ = '2.3.5'
 __author__ = 'CodingMan'
 __email__ = 'pttcodingman@gmail.com'
 

--- a/PyPtt/connect_core.py
+++ b/PyPtt/connect_core.py
@@ -22,16 +22,16 @@ from . import log
 from . import screens
 from . import ssl_config
 
+# ponytail: pass the UA per-connect instead of mutating websockets' module global.
+# The global is baked into connect()'s default arg the moment websockets lazily
+# imports asyncio.client, so mutating it only works if you get there first —
+# order-dependent action at a distance. (websockets.http also went away in 15.)
 try:
-    import websockets.http
+    from websockets.http11 import USER_AGENT as _WS_USER_AGENT
+except ImportError:  # websockets < 13
+    from websockets.http import USER_AGENT as _WS_USER_AGENT
 
-    websockets.http.USER_AGENT += f' PyPtt/{PyPtt.__version__}'
-    use_http11 = False
-except AttributeError:
-    import websockets.http11
-
-    websockets.http11.USER_AGENT += f' PyPtt/{PyPtt.__version__}'
-    use_http11 = True
+USER_AGENT = f'{_WS_USER_AGENT} PyPtt/{PyPtt.__version__}'
 
 def ssl_init(verify_ssl: bool = True) -> ssl.SSLContext:
     # Verify the PTT server certificate against the system CA bundle.
@@ -216,11 +216,11 @@ class API(object):
 
         for _ in range(2):
             try:
-                log.logger.debug('USER_AGENT',
-                                 websockets.http11.USER_AGENT if use_http11 else websockets.http.USER_AGENT)
+                log.logger.debug('USER_AGENT', USER_AGENT)
                 # ponytail: ws:// (local docker target) can't take an ssl context —
                 # websockets errors out if you pass one on a non-wss URI
-                connect_kwargs = {'origin': websocket_origin}
+                connect_kwargs = {'origin': websocket_origin,
+                                  'user_agent_header': USER_AGENT}
                 if websocket_host.startswith('wss://'):
                     connect_kwargs['ssl'] = self._ssl_context
                 self._core = loop.run_until_complete(
@@ -525,11 +525,10 @@ class API(object):
 
     def close(self):
         if self.config.connect_mode == data_type.ConnectMode.WEBSOCKETS:
-            try:
-                is_open = not self._core.closed
-            except AttributeError:
-                is_open = getattr(self._core, 'open', False)
-            if self._core and is_open:
+            # close_code is None until a close frame lands — true on both the legacy
+            # WebSocketClientProtocol and the websockets>=14 ClientConnection (which
+            # dropped .closed/.open entirely).
+            if self._core and self._core.close_code is None:
                 loop = self._get_event_loop()
                 try:
                     loop.run_until_complete(asyncio.wait_for(self._core.close(), timeout=2.0))


### PR DESCRIPTION
## 問題

master CI 全紅。`websockets` 15 移除了 `websockets.http` 模組，而 `connect_core.py` 的 UA 探測只 catch `AttributeError`：

```python
try:
    import websockets.http          # ← 15 起丟 ModuleNotFoundError
    ...
except AttributeError:              # ← 接不到
```

結果 `import PyPtt` 直接炸：

```
PyPtt/connect_core.py:26: in <module>
    import websockets.http
E   ModuleNotFoundError: No module named 'websockets.http'
```

## 修了什麼

**1. UA 探測** — 改成 `from websockets.http11 import USER_AGENT`，catch `ImportError`。模組不存在、屬性不存在兩種情況都是 `ImportError`，一個分支涵蓋，順序也反過來讓新版先試。

**2. UA 傳遞方式** — 不再改 `websockets` 的 module global，改用 `connect(user_agent_header=...)`。那個 global 會在 websockets lazy import `asyncio.client` 的當下被烤進 `connect()` 的預設參數，只有搶在前面改才有效，是 order-dependent 的 action at a distance。

**3. `close()` 的存活判定** — `.closed` → `.close_code is None`。websockets 14 起 `ClientConnection` 把 `.closed` 和 `.open` 都拿掉了，原本的 `getattr(self._core, 'open', False)` fallback 也接不住，會靜默判定「已關閉」而永遠不呼叫 `close()`（不會噴錯，但連線漏著）。

## 驗證

CI 的 15 個 unit test 檔跑過整個 `websockets>=12` 範圍：

| websockets | 12.0 | 13.1 | 14.2 | 15.0.1 | 16.1.1 | 17.0.1 |
|---|---|---|---|---|---|---|
| 結果 | 510 passed | 510 passed | 510 passed | 510 passed | 510 passed | 510 passed |

Python 3.11 與 3.14 各跑一輪。分水嶺在 **14**（`websockets.connect` 從 legacy 換成 asyncio client，`.closed` 在此消失）；`close_code` 六版皆有。

真實 PTT `login → get_time → get_user → logout`：12.0 ✅ / 17.0.1 ✅，收尾無 `Task was destroyed but it is pending`。

Handshake 封包實測，UA 格式與舊版一致（append 在 websockets 原本的 UA 後面）：

```
GET /bbs HTTP/1.1
Origin: http://localhost
User-Agent: Python/3.14 websockets/17.0.1 PyPtt/2.3.5
```

`pyproject.toml` 的 `websockets>=12` 不需調整，上下界都已實測。

## 版本

`2.3.4` → `2.3.5`。master 目前是 2.3.4，但那次 deploy 正是因為這個 bug 掛掉，2.3.4 從未發佈到 PyPI（最新仍為 2.3.3），故不重用該版號。

🤖 Generated with [Claude Code](https://claude.com/claude-code)